### PR TITLE
Add Qt-based initiative tracker scaffolding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.16)
+project(DnDInitiativeTracker LANGUAGES CXX)
+
+include(CTest)
+enable_testing()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt6 COMPONENTS Core Widgets Gui Test REQUIRED)
+if(NOT Qt6_FOUND)
+    find_package(Qt5 COMPONENTS Core Widgets Gui Test REQUIRED)
+    set(QT_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Test)
+else()
+    set(QT_LIBRARIES Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Test)
+endif()
+
+add_library(app_sources
+    src/models/Combatant.cpp
+    src/models/InitiativeModel.cpp
+    src/models/TurnManager.cpp
+    src/stores/EncounterStore.cpp
+    src/stores/RosterStore.cpp
+    src/ui/MainWindow.cpp
+    src/undo/UndoCommands.cpp
+    src/utils/DiceRoller.cpp
+    src/utils/Settings.cpp
+)
+
+target_include_directories(app_sources PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(app_sources PUBLIC ${QT_LIBRARIES})
+
+add_executable(dnd_initiative src/main.cpp)
+
+target_link_libraries(dnd_initiative PRIVATE app_sources ${QT_LIBRARIES})
+
+add_executable(testsuite tests/TestTurnManager.cpp)
+target_link_libraries(testsuite PRIVATE app_sources ${QT_LIBRARIES})
+
+add_test(NAME unit_tests COMMAND testsuite)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# D-D-initiative-tracking
+# D&D Initiative Tracker
+
+This repository contains a Qt Widgets-based initiative tracker for tabletop role-playing games. It includes a basic GUI prototype, domain model, JSON persistence helpers, and unit tests that exercise critical initiative-management rules.
+
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Run the unit tests with:
+
+```bash
+cd build
+ctest
+```
+
+Or execute the test binary directly:
+
+```bash
+./testsuite
+```
+
+## Project Layout
+
+- `src/` – C++ sources for the application
+- `tests/` – Qt Test-based unit tests
+- `docs/` – Additional documentation
+- `resources/` – Icons and themes (placeholders)
+- `data/` – Sample JSON files
+

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,0 +1,23 @@
+{
+  "schema": 2,
+  "characters": [
+    {
+      "name": "Vaelen",
+      "dexMod": 3,
+      "isPC": true,
+      "tags": ["pc", "paladin"],
+      "defaultHP": 38,
+      "defaultAC": 18,
+      "defaultNotes": "Aura of Protection"
+    },
+    {
+      "name": "Bandit",
+      "dexMod": 2,
+      "isPC": false,
+      "tags": ["npc", "human"],
+      "defaultHP": 11,
+      "defaultAC": 12,
+      "defaultNotes": "Pack tactics"
+    }
+  ]
+}

--- a/data/groups.json
+++ b/data/groups.json
@@ -1,0 +1,23 @@
+{
+  "schema": 2,
+  "groups": [
+    {
+      "name": "Bandit Ambush",
+      "entries": [
+        {"character": "Bandit", "count": 4}
+      ]
+    },
+    {
+      "name": "Heroes",
+      "entries": [
+        {"character": "Vaelen", "count": 1}
+      ]
+    }
+  ],
+  "naming": {
+    "pattern": "%name %index",
+    "startIndex": 1,
+    "zeroPad": true,
+    "width": 2
+  }
+}

--- a/data/sample_encounter.json
+++ b/data/sample_encounter.json
@@ -1,0 +1,33 @@
+{
+  "schema": 2,
+  "round": 1,
+  "turnIndex": 0,
+  "combatants": [
+    {
+      "id": 1,
+      "name": "Vaelen",
+      "initiative": 18,
+      "dexMod": 3,
+      "isPC": true,
+      "conscious": true,
+      "hp": 38,
+      "ac": 18,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [{"name": "Bless", "remainingRounds": 8}],
+      "notes": "Protect the wizard"
+    },
+    {
+      "id": 2,
+      "name": "Bandit 01",
+      "initiative": 14,
+      "dexMod": 2,
+      "isPC": false,
+      "conscious": true,
+      "hp": 11,
+      "ac": 12,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [],
+      "notes": ""
+    }
+  ]
+}

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,37 @@
+# Build and Deployment Notes
+
+## Prerequisites
+
+- CMake 3.16+
+- A C++17 compiler
+- Qt 6 (Widgets, Gui, Core, Test). Qt 5.15+ is also supported.
+
+## Configure and Build
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+### Deploying
+
+#### Windows
+
+Use `windeployqt` with the built executable:
+
+```powershell
+windeployqt --release path\to\dnd_initiative.exe
+```
+
+#### macOS
+
+Use `macdeployqt` to bundle frameworks:
+
+```bash
+macdeployqt dnd_initiative.app
+```
+
+#### Linux
+
+Consider packaging as an AppImage using [linuxdeployqt](https://github.com/probonopd/linuxdeployqt).
+

--- a/docs/JSON.md
+++ b/docs/JSON.md
@@ -1,0 +1,68 @@
+# JSON Schemas
+
+## Encounter (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "round": 1,
+  "turnIndex": 0,
+  "combatants": [
+    {
+      "id": 1,
+      "name": "Vaelen",
+      "initiative": 17,
+      "dexMod": 3,
+      "isPC": true,
+      "conscious": true,
+      "hp": 27,
+      "ac": 17,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [{"name": "Bless", "remainingRounds": 8}],
+      "notes": "Focus fire on the wight."
+    }
+  ]
+}
+```
+
+## Characters (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "characters": [
+    {
+      "name": "Bandit",
+      "dexMod": 2,
+      "isPC": false,
+      "tags": ["human", "bandit"],
+      "defaultHP": 11,
+      "defaultAC": 12,
+      "defaultNotes": ""
+    }
+  ]
+}
+```
+
+## Groups (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "groups": [
+    {
+      "name": "Bandits x6",
+      "entries": [
+        {"character": "Bandit", "count": 6}
+      ]
+    }
+  ],
+  "naming": {
+    "pattern": "%name %index",
+    "startIndex": 1,
+    "zeroPad": true,
+    "width": 2
+  }
+}
+```
+

--- a/resources/icons/README.md
+++ b/resources/icons/README.md
@@ -1,0 +1,1 @@
+Placeholder directory for application icons.

--- a/resources/themes/dark.qss
+++ b/resources/themes/dark.qss
@@ -1,0 +1,3 @@
+/* Placeholder dark theme */
+QMainWindow { background: #1e1e1e; color: #f0f0f0; }
+QTableView { background: #2b2b2b; color: #f0f0f0; gridline-color: #444; }

--- a/resources/themes/light.qss
+++ b/resources/themes/light.qss
@@ -1,0 +1,3 @@
+/* Placeholder light theme */
+QMainWindow { background: #f7f7f7; }
+QTableView { gridline-color: #d0d0d0; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,11 @@
+#include <QApplication>
+
+#include "ui/MainWindow.h"
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    MainWindow window;
+    window.show();
+    return app.exec();
+}
+

--- a/src/models/Combatant.cpp
+++ b/src/models/Combatant.cpp
@@ -1,0 +1,46 @@
+#include "Combatant.h"
+
+void DeathSaves::reset() noexcept {
+    successes = 0;
+    failures = 0;
+    dead = false;
+    stable = false;
+}
+
+void DeathSaves::recordSuccess() noexcept {
+    if (dead) {
+        return;
+    }
+    if (successes < 3) {
+        ++successes;
+    }
+    if (successes >= 3) {
+        stable = true;
+        failures = 0;
+    }
+}
+
+void DeathSaves::recordFailure() noexcept {
+    if (stable) {
+        return;
+    }
+    if (failures < 3) {
+        ++failures;
+    }
+    if (failures >= 3) {
+        dead = true;
+    }
+}
+
+bool operator==(const Condition &lhs, const Condition &rhs) noexcept {
+    return lhs.name == rhs.name && lhs.remainingRounds == rhs.remainingRounds;
+}
+
+bool operator==(const DeathSaves &lhs, const DeathSaves &rhs) noexcept {
+    return lhs.successes == rhs.successes && lhs.failures == rhs.failures && lhs.dead == rhs.dead && lhs.stable == rhs.stable;
+}
+
+bool operator==(const Combatant &lhs, const Combatant &rhs) noexcept {
+    return lhs.id == rhs.id && lhs.name == rhs.name && lhs.initiative == rhs.initiative && lhs.dexMod == rhs.dexMod && lhs.isPC == rhs.isPC && lhs.conscious == rhs.conscious && lhs.hp == rhs.hp && lhs.ac == rhs.ac && lhs.deathSaves == rhs.deathSaves && lhs.conditions == rhs.conditions && lhs.notes == rhs.notes;
+}
+

--- a/src/models/Combatant.h
+++ b/src/models/Combatant.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+struct Condition {
+    QString name;
+    int remainingRounds = 0;
+
+    bool isExpired() const noexcept { return remainingRounds <= 0; }
+};
+
+struct DeathSaves {
+    int successes = 0;
+    int failures = 0;
+    bool dead = false;
+    bool stable = false;
+
+    void reset() noexcept;
+    void recordSuccess() noexcept;
+    void recordFailure() noexcept;
+};
+
+struct Combatant {
+    int id = 0;
+    QString name;
+    int initiative = 0;
+    int dexMod = 0;
+    bool isPC = false;
+    bool conscious = true;
+    int hp = 0;
+    int ac = 10;
+    DeathSaves deathSaves;
+    QVector<Condition> conditions;
+    QString notes;
+};
+
+bool operator==(const Condition &lhs, const Condition &rhs) noexcept;
+bool operator==(const DeathSaves &lhs, const DeathSaves &rhs) noexcept;
+bool operator==(const Combatant &lhs, const Combatant &rhs) noexcept;
+

--- a/src/models/InitiativeModel.cpp
+++ b/src/models/InitiativeModel.cpp
@@ -1,0 +1,161 @@
+#include "InitiativeModel.h"
+
+#include <QBrush>
+
+InitiativeModel::InitiativeModel(TurnManager *manager, QObject *parent)
+    : QAbstractTableModel(parent)
+    , m_manager(manager) {}
+
+int InitiativeModel::rowCount(const QModelIndex &parent) const {
+    if (parent.isValid() || !m_manager) {
+        return 0;
+    }
+    return m_manager->combatants().size();
+}
+
+int InitiativeModel::columnCount(const QModelIndex &parent) const {
+    if (parent.isValid()) {
+        return 0;
+    }
+    return ColumnCount;
+}
+
+QVariant InitiativeModel::data(const QModelIndex &index, int role) const {
+    if (!m_manager || !index.isValid()) {
+        return QVariant();
+    }
+    const auto &combatants = m_manager->combatants();
+    if (index.row() >= combatants.size()) {
+        return QVariant();
+    }
+    const auto &combatant = combatants.at(index.row());
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case ColumnIndex:
+            return index.row() + 1;
+        case ColumnName:
+            return combatant.name;
+        case ColumnInitiative:
+            return combatant.initiative;
+        case ColumnDex:
+            return combatant.dexMod;
+        case ColumnType:
+            return combatant.isPC ? tr("PC") : tr("NPC");
+        case ColumnStatus:
+            return combatant.conscious ? tr("OK") : tr("Down");
+        case ColumnHP:
+            return combatant.hp;
+        case ColumnAC:
+            return combatant.ac;
+        case ColumnConditions: {
+            QStringList names;
+            for (const auto &condition : combatant.conditions) {
+                names << QStringLiteral("%1 (%2)").arg(condition.name).arg(condition.remainingRounds);
+            }
+            return names.join(", ");
+        }
+        case ColumnNotes:
+            return combatant.notes;
+        default:
+            break;
+        }
+    }
+
+    if (role == Qt::ToolTipRole && index.column() == ColumnNotes) {
+        return combatant.notes;
+    }
+
+    if (role == Qt::ForegroundRole && !combatant.conscious) {
+        return QBrush(Qt::gray);
+    }
+    return QVariant();
+}
+
+QVariant InitiativeModel::headerData(int section, Qt::Orientation orientation, int role) const {
+    if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
+        switch (section) {
+        case ColumnIndex:
+            return tr("#");
+        case ColumnName:
+            return tr("Name");
+        case ColumnInitiative:
+            return tr("Init");
+        case ColumnDex:
+            return tr("Dex");
+        case ColumnType:
+            return tr("Type");
+        case ColumnStatus:
+            return tr("Status");
+        case ColumnHP:
+            return tr("HP");
+        case ColumnAC:
+            return tr("AC");
+        case ColumnConditions:
+            return tr("Conditions");
+        case ColumnNotes:
+            return tr("Notes");
+        default:
+            break;
+        }
+    }
+    return QAbstractTableModel::headerData(section, orientation, role);
+}
+
+Qt::ItemFlags InitiativeModel::flags(const QModelIndex &index) const {
+    if (!index.isValid()) {
+        return Qt::NoItemFlags;
+    }
+    Qt::ItemFlags itemFlags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    switch (index.column()) {
+    case ColumnName:
+    case ColumnInitiative:
+    case ColumnDex:
+    case ColumnHP:
+    case ColumnAC:
+    case ColumnNotes:
+        itemFlags |= Qt::ItemIsEditable;
+        break;
+    default:
+        break;
+    }
+    return itemFlags;
+}
+
+bool InitiativeModel::setData(const QModelIndex &index, const QVariant &value, int role) {
+    if (!m_manager || role != Qt::EditRole || !index.isValid()) {
+        return false;
+    }
+    auto &combatant = m_manager->combatants()[index.row()];
+    switch (index.column()) {
+    case ColumnName:
+        combatant.name = value.toString();
+        break;
+    case ColumnInitiative:
+        combatant.initiative = value.toInt();
+        m_manager->sortCombatants();
+        break;
+    case ColumnDex:
+        combatant.dexMod = value.toInt();
+        m_manager->sortCombatants();
+        break;
+    case ColumnHP:
+        combatant.hp = value.toInt();
+        break;
+    case ColumnAC:
+        combatant.ac = value.toInt();
+        break;
+    case ColumnNotes:
+        combatant.notes = value.toString();
+        break;
+    default:
+        return false;
+    }
+    emit dataChanged(index, index);
+    return true;
+}
+
+void InitiativeModel::refresh() {
+    beginResetModel();
+    endResetModel();
+}
+

--- a/src/models/InitiativeModel.h
+++ b/src/models/InitiativeModel.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QAbstractTableModel>
+
+#include "TurnManager.h"
+
+class InitiativeModel : public QAbstractTableModel {
+    Q_OBJECT
+public:
+    enum Columns {
+        ColumnIndex,
+        ColumnName,
+        ColumnInitiative,
+        ColumnDex,
+        ColumnType,
+        ColumnStatus,
+        ColumnHP,
+        ColumnAC,
+        ColumnConditions,
+        ColumnNotes,
+        ColumnCount
+    };
+
+    explicit InitiativeModel(TurnManager *manager, QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+
+    void refresh();
+
+private:
+    TurnManager *m_manager;
+};
+

--- a/src/models/TurnManager.cpp
+++ b/src/models/TurnManager.cpp
@@ -1,0 +1,157 @@
+#include "TurnManager.h"
+
+#include <algorithm>
+
+TurnManager::CombatantList &TurnManager::combatants() {
+    return m_combatants;
+}
+
+const TurnManager::CombatantList &TurnManager::combatants() const {
+    return m_combatants;
+}
+
+void TurnManager::setCombatants(CombatantList list) {
+    m_combatants = std::move(list);
+    sortCombatants();
+    normalizeTurnIndex();
+}
+
+void TurnManager::addCombatant(const Combatant &combatant) {
+    m_combatants.push_back(combatant);
+    sortCombatants();
+    normalizeTurnIndex();
+}
+
+bool TurnManager::removeCombatant(int id) {
+    const auto it = std::remove_if(m_combatants.begin(), m_combatants.end(), [id](const Combatant &c) { return c.id == id; });
+    if (it == m_combatants.end()) {
+        return false;
+    }
+    const int removedIndex = std::distance(m_combatants.begin(), it);
+    m_combatants.erase(it, m_combatants.end());
+    if (m_turnIndex >= static_cast<int>(m_combatants.size())) {
+        m_turnIndex = std::max(0, static_cast<int>(m_combatants.size()) - 1);
+    }
+    if (removedIndex <= m_turnIndex) {
+        normalizeTurnIndex();
+    }
+    return true;
+}
+
+std::optional<Combatant> TurnManager::combatantById(int id) const {
+    const auto it = std::find_if(m_combatants.begin(), m_combatants.end(), [id](const Combatant &c) { return c.id == id; });
+    if (it == m_combatants.end()) {
+        return std::nullopt;
+    }
+    return *it;
+}
+
+static bool combatantLess(const Combatant &lhs, const Combatant &rhs) {
+    if (lhs.initiative != rhs.initiative) {
+        return lhs.initiative > rhs.initiative;
+    }
+    if (lhs.dexMod != rhs.dexMod) {
+        return lhs.dexMod > rhs.dexMod;
+    }
+    if (lhs.isPC != rhs.isPC) {
+        return lhs.isPC && !rhs.isPC;
+    }
+    const auto lhsName = lhs.name.toCaseFolded();
+    const auto rhsName = rhs.name.toCaseFolded();
+    return lhsName < rhsName;
+}
+
+void TurnManager::sortCombatants() {
+    std::stable_sort(m_combatants.begin(), m_combatants.end(), combatantLess);
+}
+
+bool TurnManager::advanceTurn() {
+    if (m_combatants.isEmpty()) {
+        return false;
+    }
+
+    decrementConditionsForCurrent();
+
+    const int size = m_combatants.size();
+    int attempts = 0;
+    do {
+        ++m_turnIndex;
+        if (m_turnIndex >= size) {
+            m_turnIndex = 0;
+            ++m_round;
+        }
+        ++attempts;
+        if (!m_skipUnconscious) {
+            break;
+        }
+    } while (attempts <= size && !m_combatants[m_turnIndex].conscious);
+
+    return true;
+}
+
+bool TurnManager::rewindTurn() {
+    if (m_combatants.isEmpty()) {
+        return false;
+    }
+
+    const int size = m_combatants.size();
+    int attempts = 0;
+    do {
+        --m_turnIndex;
+        if (m_turnIndex < 0) {
+            m_turnIndex = size - 1;
+            m_round = std::max(1, m_round - 1);
+        }
+        ++attempts;
+        if (!m_skipUnconscious) {
+            break;
+        }
+    } while (attempts <= size && !m_combatants[m_turnIndex].conscious);
+
+    return true;
+}
+
+void TurnManager::forEachCombatant(const std::function<void(Combatant &)> &visitor) {
+    for (auto &combatant : m_combatants) {
+        visitor(combatant);
+    }
+}
+
+void TurnManager::resetInitiativeOrder() {
+    m_round = 1;
+    m_turnIndex = 0;
+    sortCombatants();
+}
+
+void TurnManager::decrementConditionsForCurrent() {
+    if (m_combatants.isEmpty()) {
+        return;
+    }
+    Combatant &current = m_combatants[m_turnIndex];
+    for (auto &condition : current.conditions) {
+        if (condition.remainingRounds > 0) {
+            --condition.remainingRounds;
+        }
+    }
+    current.conditions.erase(std::remove_if(current.conditions.begin(), current.conditions.end(), [](const Condition &c) {
+        return c.isExpired();
+    }), current.conditions.end());
+}
+
+void TurnManager::normalizeTurnIndex() {
+    if (m_combatants.isEmpty()) {
+        m_turnIndex = 0;
+        m_round = 1;
+        return;
+    }
+    if (m_turnIndex >= m_combatants.size()) {
+        m_turnIndex = m_combatants.size() - 1;
+    }
+    if (m_turnIndex < 0) {
+        m_turnIndex = 0;
+    }
+    if (m_round < 1) {
+        m_round = 1;
+    }
+}
+

--- a/src/models/TurnManager.h
+++ b/src/models/TurnManager.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "Combatant.h"
+
+#include <QVector>
+#include <functional>
+#include <optional>
+
+class TurnManager {
+public:
+    using CombatantList = QVector<Combatant>;
+
+    CombatantList &combatants();
+    const CombatantList &combatants() const;
+
+    void setCombatants(CombatantList list);
+
+    void addCombatant(const Combatant &combatant);
+    bool removeCombatant(int id);
+    std::optional<Combatant> combatantById(int id) const;
+
+    void sortCombatants();
+
+    int round() const noexcept { return m_round; }
+    int turnIndex() const noexcept { return m_turnIndex; }
+
+    bool advanceTurn();
+    bool rewindTurn();
+
+    void forEachCombatant(const std::function<void(Combatant &)> &visitor);
+
+    void resetInitiativeOrder();
+
+    void decrementConditionsForCurrent();
+
+    void setSkipUnconscious(bool skip) noexcept { m_skipUnconscious = skip; }
+    bool skipUnconscious() const noexcept { return m_skipUnconscious; }
+
+private:
+    void normalizeTurnIndex();
+
+    CombatantList m_combatants;
+    int m_round = 1;
+    int m_turnIndex = 0;
+    bool m_skipUnconscious = true;
+};
+

--- a/src/stores/EncounterStore.cpp
+++ b/src/stores/EncounterStore.cpp
@@ -1,0 +1,126 @@
+#include "EncounterStore.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace {
+constexpr int kSchemaVersion = 2;
+
+QJsonObject toJson(const Combatant &combatant) {
+    QJsonObject obj;
+    obj["id"] = combatant.id;
+    obj["name"] = combatant.name;
+    obj["initiative"] = combatant.initiative;
+    obj["dexMod"] = combatant.dexMod;
+    obj["isPC"] = combatant.isPC;
+    obj["conscious"] = combatant.conscious;
+    obj["hp"] = combatant.hp;
+    obj["ac"] = combatant.ac;
+    QJsonObject ds;
+    ds["successes"] = combatant.deathSaves.successes;
+    ds["failures"] = combatant.deathSaves.failures;
+    ds["dead"] = combatant.deathSaves.dead;
+    ds["stable"] = combatant.deathSaves.stable;
+    obj["deathSaves"] = ds;
+    QJsonArray conditions;
+    for (const auto &condition : combatant.conditions) {
+        QJsonObject conditionObj;
+        conditionObj["name"] = condition.name;
+        conditionObj["remainingRounds"] = condition.remainingRounds;
+        conditions.push_back(conditionObj);
+    }
+    obj["conditions"] = conditions;
+    obj["notes"] = combatant.notes;
+    return obj;
+}
+
+Combatant combatantFromJson(const QJsonObject &obj) {
+    Combatant combatant;
+    combatant.id = obj.value("id").toInt();
+    combatant.name = obj.value("name").toString();
+    combatant.initiative = obj.value("initiative").toInt();
+    combatant.dexMod = obj.value("dexMod").toInt();
+    combatant.isPC = obj.value("isPC").toBool();
+    combatant.conscious = obj.value("conscious").toBool(true);
+    combatant.hp = obj.value("hp").toInt();
+    combatant.ac = obj.value("ac").toInt();
+    const auto ds = obj.value("deathSaves").toObject();
+    combatant.deathSaves.successes = ds.value("successes").toInt();
+    combatant.deathSaves.failures = ds.value("failures").toInt();
+    combatant.deathSaves.dead = ds.value("dead").toBool();
+    combatant.deathSaves.stable = ds.value("stable").toBool();
+    for (const auto &conditionValue : obj.value("conditions").toArray()) {
+        const auto conditionObj = conditionValue.toObject();
+        Condition condition;
+        condition.name = conditionObj.value("name").toString();
+        condition.remainingRounds = conditionObj.value("remainingRounds").toInt();
+        combatant.conditions.push_back(condition);
+    }
+    combatant.notes = obj.value("notes").toString();
+    return combatant;
+}
+}
+
+EncounterStore::EncounterStore(QObject *parent)
+    : QObject(parent) {}
+
+void EncounterStore::setFilePath(QString path) {
+    m_filePath = std::move(path);
+}
+
+bool EncounterStore::load(TurnManager &manager, int &round, int &turnIndex) const {
+    if (m_filePath.isEmpty()) {
+        return false;
+    }
+    QFile file(m_filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+    const auto data = file.readAll();
+    return deserialize(data, manager, round, turnIndex);
+}
+
+bool EncounterStore::save(const TurnManager &manager, int round, int turnIndex) const {
+    if (m_filePath.isEmpty()) {
+        return false;
+    }
+    QFile file(m_filePath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    file.write(serialize(manager, round, turnIndex));
+    return true;
+}
+
+QByteArray EncounterStore::serialize(const TurnManager &manager, int round, int turnIndex) {
+    QJsonObject root;
+    root["schema"] = kSchemaVersion;
+    root["round"] = round;
+    root["turnIndex"] = turnIndex;
+    QJsonArray combatants;
+    for (const auto &combatant : manager.combatants()) {
+        combatants.push_back(toJson(combatant));
+    }
+    root["combatants"] = combatants;
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+bool EncounterStore::deserialize(const QByteArray &data, TurnManager &manager, int &round, int &turnIndex) {
+    const auto doc = QJsonDocument::fromJson(data);
+    const auto root = doc.object();
+    if (root.value("schema").toInt() != kSchemaVersion) {
+        return false;
+    }
+    round = root.value("round").toInt(1);
+    turnIndex = root.value("turnIndex").toInt(0);
+
+    TurnManager::CombatantList list;
+    for (const auto &value : root.value("combatants").toArray()) {
+        list.push_back(combatantFromJson(value.toObject()));
+    }
+    manager.setCombatants(list);
+    return true;
+}
+

--- a/src/stores/EncounterStore.h
+++ b/src/stores/EncounterStore.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include "models/TurnManager.h"
+
+class EncounterStore : public QObject {
+    Q_OBJECT
+public:
+    explicit EncounterStore(QObject *parent = nullptr);
+
+    void setFilePath(QString path);
+    QString filePath() const { return m_filePath; }
+
+    bool load(TurnManager &manager, int &round, int &turnIndex) const;
+    bool save(const TurnManager &manager, int round, int turnIndex) const;
+
+    static QByteArray serialize(const TurnManager &manager, int round, int turnIndex);
+    static bool deserialize(const QByteArray &data, TurnManager &manager, int &round, int &turnIndex);
+
+private:
+    QString m_filePath;
+};
+

--- a/src/stores/RosterStore.cpp
+++ b/src/stores/RosterStore.cpp
@@ -1,0 +1,264 @@
+#include "RosterStore.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+
+#include <algorithm>
+
+namespace {
+constexpr int kSchemaVersion = 2;
+
+QJsonObject toJson(const RosterCharacter &character) {
+    QJsonObject obj;
+    obj["name"] = character.name;
+    obj["dexMod"] = character.dexMod;
+    obj["isPC"] = character.isPC;
+    QStringList tagsList;
+    tagsList.reserve(character.tags.size());
+    for (const auto &tag : character.tags) {
+        tagsList.append(tag);
+    }
+    obj["tags"] = QJsonArray::fromStringList(tagsList);
+    obj["defaultHP"] = character.defaultHP;
+    obj["defaultAC"] = character.defaultAC;
+    obj["defaultNotes"] = character.defaultNotes;
+    return obj;
+}
+
+RosterCharacter characterFromJson(const QJsonObject &obj) {
+    RosterCharacter character;
+    character.name = obj.value("name").toString();
+    character.dexMod = obj.value("dexMod").toInt();
+    character.isPC = obj.value("isPC").toBool();
+    for (const auto &tag : obj.value("tags").toArray()) {
+        character.tags.insert(tag.toString());
+    }
+    character.defaultHP = obj.value("defaultHP").toInt();
+    character.defaultAC = obj.value("defaultAC").toInt();
+    character.defaultNotes = obj.value("defaultNotes").toString();
+    return character;
+}
+
+QJsonObject toJson(const RosterGroup &group) {
+    QJsonObject obj;
+    obj["name"] = group.name;
+    QJsonArray entries;
+    for (const auto &entry : group.entries) {
+        QJsonObject entryObj;
+        entryObj["character"] = entry.characterName;
+        entryObj["count"] = entry.count;
+        entries.push_back(entryObj);
+    }
+    obj["entries"] = entries;
+    return obj;
+}
+
+RosterGroup groupFromJson(const QJsonObject &obj) {
+    RosterGroup group;
+    group.name = obj.value("name").toString();
+    for (const auto &entryValue : obj.value("entries").toArray()) {
+        const auto entryObj = entryValue.toObject();
+        RosterGroupEntry entry;
+        entry.characterName = entryObj.value("character").toString();
+        entry.count = entryObj.value("count").toInt(1);
+        group.entries.push_back(entry);
+    }
+    return group;
+}
+}
+
+RosterStore::RosterStore(QObject *parent)
+    : QObject(parent) {
+    QString dataLocation = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if (dataLocation.isEmpty()) {
+        dataLocation = QDir::homePath() + "/.dnd-initiative";
+    }
+    setBasePath(dataLocation);
+}
+
+void RosterStore::setBasePath(QString path) {
+    m_basePath = std::move(path);
+    QDir().mkpath(m_basePath);
+}
+
+void RosterStore::setCharacters(QVector<RosterCharacter> characters) {
+    m_characters = std::move(characters);
+    emit dataChanged();
+}
+
+void RosterStore::setGroups(QVector<RosterGroup> groups) {
+    m_groups = std::move(groups);
+    emit dataChanged();
+}
+
+void RosterStore::setDefaultNaming(const MassAddNaming &naming) {
+    m_defaultNaming = naming;
+    emit dataChanged();
+}
+
+QString RosterStore::charactersPath() const {
+    return m_basePath + "/characters.json";
+}
+
+QString RosterStore::groupsPath() const {
+    return m_basePath + "/groups.json";
+}
+
+bool RosterStore::load() {
+    QFile charactersFile(charactersPath());
+    if (charactersFile.exists() && charactersFile.open(QIODevice::ReadOnly)) {
+        const auto doc = QJsonDocument::fromJson(charactersFile.readAll());
+        const auto root = doc.object();
+        const auto schema = root.value("schema").toInt();
+        if (schema == kSchemaVersion) {
+            m_characters.clear();
+            for (const auto &value : root.value("characters").toArray()) {
+                m_characters.push_back(characterFromJson(value.toObject()));
+            }
+        }
+    }
+
+    QFile groupsFile(groupsPath());
+    if (groupsFile.exists() && groupsFile.open(QIODevice::ReadOnly)) {
+        const auto doc = QJsonDocument::fromJson(groupsFile.readAll());
+        const auto root = doc.object();
+        const auto schema = root.value("schema").toInt();
+        if (schema == kSchemaVersion) {
+            m_groups.clear();
+            for (const auto &value : root.value("groups").toArray()) {
+                m_groups.push_back(groupFromJson(value.toObject()));
+            }
+            const auto namingObj = root.value("naming").toObject();
+            if (!namingObj.isEmpty()) {
+                m_defaultNaming.pattern = namingObj.value("pattern").toString(m_defaultNaming.pattern);
+                m_defaultNaming.startIndex = namingObj.value("startIndex").toInt(m_defaultNaming.startIndex);
+                m_defaultNaming.zeroPad = namingObj.value("zeroPad").toBool(m_defaultNaming.zeroPad);
+                m_defaultNaming.width = namingObj.value("width").toInt(m_defaultNaming.width);
+            }
+        }
+    }
+
+    emit dataChanged();
+    return true;
+}
+
+bool RosterStore::save() const {
+    QJsonObject charactersRoot;
+    charactersRoot["schema"] = kSchemaVersion;
+    QJsonArray characterArray;
+    for (const auto &character : m_characters) {
+        characterArray.push_back(toJson(character));
+    }
+    charactersRoot["characters"] = characterArray;
+    QFile charactersFile(charactersPath());
+    if (!charactersFile.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    charactersFile.write(QJsonDocument(charactersRoot).toJson(QJsonDocument::Indented));
+
+    QJsonObject groupsRoot;
+    groupsRoot["schema"] = kSchemaVersion;
+    QJsonArray groupArray;
+    for (const auto &group : m_groups) {
+        groupArray.push_back(toJson(group));
+    }
+    groupsRoot["groups"] = groupArray;
+    QJsonObject naming;
+    naming["pattern"] = m_defaultNaming.pattern;
+    naming["startIndex"] = m_defaultNaming.startIndex;
+    naming["zeroPad"] = m_defaultNaming.zeroPad;
+    naming["width"] = m_defaultNaming.width;
+    groupsRoot["naming"] = naming;
+
+    QFile groupsFile(groupsPath());
+    if (!groupsFile.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    groupsFile.write(QJsonDocument(groupsRoot).toJson(QJsonDocument::Indented));
+
+    return true;
+}
+
+QVector<RosterCharacter> RosterStore::filterCharacters(const QString &text, const QSet<QString> &tags) const {
+    QVector<RosterCharacter> results;
+    const auto lower = text.toCaseFolded();
+    for (const auto &character : m_characters) {
+        if (!text.isEmpty() && !character.name.toCaseFolded().contains(lower)) {
+            continue;
+        }
+        if (!tags.isEmpty()) {
+            bool matchesAll = true;
+            for (const auto &tag : tags) {
+                if (!character.tags.contains(tag)) {
+                    matchesAll = false;
+                    break;
+                }
+            }
+            if (!matchesAll) {
+                continue;
+            }
+        }
+        results.push_back(character);
+    }
+    return results;
+}
+
+static QString formatName(const QString &pattern, const QString &name, int index, bool zeroPad, int width) {
+    QString formatted = pattern;
+    QString indexStr = QString::number(index);
+    if (zeroPad) {
+        indexStr = QString("%1").arg(index, width, 10, QLatin1Char('0'));
+    }
+    formatted.replace("%name", name);
+    formatted.replace("%index", indexStr);
+    return formatted;
+}
+
+QVector<Combatant> RosterStore::massAdd(const QString &characterName, int count, const MassAddNaming &naming) const {
+    QVector<Combatant> added;
+    const auto it = std::find_if(m_characters.begin(), m_characters.end(), [&](const RosterCharacter &c) {
+        return c.name.compare(characterName, Qt::CaseInsensitive) == 0;
+    });
+    if (it == m_characters.end() || count <= 0) {
+        return added;
+    }
+
+    for (int i = 0; i < count; ++i) {
+        Combatant combatant;
+        combatant.name = formatName(naming.pattern, it->name, naming.startIndex + i, naming.zeroPad, naming.width);
+        combatant.dexMod = it->dexMod;
+        combatant.isPC = it->isPC;
+        combatant.hp = it->defaultHP;
+        combatant.ac = it->defaultAC;
+        combatant.notes = it->defaultNotes;
+        added.push_back(combatant);
+    }
+    return added;
+}
+
+QVector<Combatant> RosterStore::massAddGroup(const QString &groupName, const MassAddNaming &naming) const {
+    QVector<Combatant> combatants;
+    const auto it = std::find_if(m_groups.begin(), m_groups.end(), [&](const RosterGroup &group) {
+        return group.name.compare(groupName, Qt::CaseInsensitive) == 0;
+    });
+    if (it == m_groups.end()) {
+        return combatants;
+    }
+
+    int offset = 0;
+    for (const auto &entry : it->entries) {
+        MassAddNaming entryNaming = naming;
+        entryNaming.startIndex = naming.startIndex + offset;
+        const auto added = massAdd(entry.characterName, entry.count, entryNaming);
+        for (const auto &combatant : added) {
+            combatants.push_back(combatant);
+        }
+        offset += entry.count;
+    }
+    return combatants;
+}
+

--- a/src/stores/RosterStore.h
+++ b/src/stores/RosterStore.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QVector>
+
+#include "models/Combatant.h"
+
+struct RosterCharacter {
+    QString name;
+    int dexMod = 0;
+    bool isPC = false;
+    QSet<QString> tags;
+    int defaultHP = 0;
+    int defaultAC = 10;
+    QString defaultNotes;
+};
+
+struct RosterGroupEntry {
+    QString characterName;
+    int count = 1;
+};
+
+struct RosterGroup {
+    QString name;
+    QVector<RosterGroupEntry> entries;
+};
+
+struct MassAddNaming {
+    QString pattern = "%name #%index";
+    int startIndex = 1;
+    bool zeroPad = false;
+    int width = 2;
+};
+
+class RosterStore : public QObject {
+    Q_OBJECT
+public:
+    explicit RosterStore(QObject *parent = nullptr);
+
+    const QVector<RosterCharacter> &characters() const noexcept { return m_characters; }
+    const QVector<RosterGroup> &groups() const noexcept { return m_groups; }
+    const MassAddNaming &defaultNaming() const noexcept { return m_defaultNaming; }
+
+    void setCharacters(QVector<RosterCharacter> characters);
+    void setGroups(QVector<RosterGroup> groups);
+    void setDefaultNaming(const MassAddNaming &naming);
+
+    void setBasePath(QString path);
+
+    bool load();
+    bool save() const;
+
+    QVector<RosterCharacter> filterCharacters(const QString &text, const QSet<QString> &tags) const;
+    QVector<Combatant> massAdd(const QString &characterName, int count, const MassAddNaming &naming) const;
+    QVector<Combatant> massAddGroup(const QString &groupName, const MassAddNaming &naming) const;
+
+signals:
+    void dataChanged();
+
+private:
+    QString charactersPath() const;
+    QString groupsPath() const;
+
+    QVector<RosterCharacter> m_characters;
+    QVector<RosterGroup> m_groups;
+    MassAddNaming m_defaultNaming;
+    QString m_basePath;
+};
+

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -1,0 +1,188 @@
+#include "MainWindow.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QDockWidget>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QItemSelectionModel>
+#include <QMenu>
+#include <QMenuBar>
+#include <QSpinBox>
+#include <QStatusBar>
+#include <QTableView>
+#include <QTextEdit>
+#include <QToolBar>
+
+#include "undo/UndoCommands.h"
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+    , m_model(&m_turnManager, this) {
+    setupUi();
+    setupMenus();
+    connectSignals();
+    populateSampleData();
+    updateStatusBar();
+}
+
+void MainWindow::setupUi() {
+    m_tableView = new QTableView(this);
+    m_tableView->setModel(&m_model);
+    setCentralWidget(m_tableView);
+
+    auto *editorDock = new QDockWidget(tr("Editor"), this);
+    auto *editorWidget = new QWidget(editorDock);
+    auto *form = new QFormLayout(editorWidget);
+    m_nameEdit = new QLineEdit(editorWidget);
+    m_initiativeSpin = new QSpinBox(editorWidget);
+    m_initiativeSpin->setRange(-10, 40);
+    m_notesEdit = new QTextEdit(editorWidget);
+    form->addRow(tr("Name"), m_nameEdit);
+    form->addRow(tr("Initiative"), m_initiativeSpin);
+    form->addRow(tr("Notes"), m_notesEdit);
+    editorWidget->setLayout(form);
+    editorDock->setWidget(editorWidget);
+    addDockWidget(Qt::RightDockWidgetArea, editorDock);
+
+    auto *toolBar = addToolBar(tr("Turns"));
+    toolBar->addAction(tr("Prev"), this, &MainWindow::handlePreviousTurn);
+    toolBar->addAction(tr("Next"), this, &MainWindow::handleNextTurn);
+
+    statusBar()->showMessage(tr("Ready"));
+}
+
+void MainWindow::setupMenus() {
+    auto *turnMenu = menuBar()->addMenu(tr("Encounter"));
+    turnMenu->addAction(tr("Previous Turn"), this, &MainWindow::handlePreviousTurn, QKeySequence(Qt::Key_PageUp));
+    turnMenu->addAction(tr("Next Turn"), this, &MainWindow::handleNextTurn, QKeySequence(Qt::Key_PageDown));
+
+    auto *rollMenu = menuBar()->addMenu(tr("Roll"));
+    rollMenu->addAction(tr("Normal"), this, &MainWindow::handleRollNormal, QKeySequence(tr("Ctrl+R")));
+    rollMenu->addAction(tr("Advantage"), this, &MainWindow::handleRollAdvantage);
+    rollMenu->addAction(tr("Disadvantage"), this, &MainWindow::handleRollDisadvantage);
+}
+
+void MainWindow::connectSignals() {
+    connect(m_tableView->selectionModel(), &QItemSelectionModel::currentRowChanged, this, [this](const QModelIndex &current) {
+        if (!current.isValid()) {
+            return;
+        }
+        const auto &combatant = m_turnManager.combatants().at(current.row());
+        m_nameEdit->setText(combatant.name);
+        m_initiativeSpin->setValue(combatant.initiative);
+        m_notesEdit->setPlainText(combatant.notes);
+    });
+
+    connect(m_nameEdit, &QLineEdit::textEdited, this, [this](const QString &text) {
+        const auto index = m_tableView->currentIndex();
+        if (index.isValid()) {
+            m_model.setData(m_model.index(index.row(), InitiativeModel::ColumnName), text, Qt::EditRole);
+        }
+    });
+
+    connect(m_initiativeSpin, &QSpinBox::valueChanged, this, [this](int value) {
+        const auto index = m_tableView->currentIndex();
+        if (index.isValid()) {
+            m_model.setData(m_model.index(index.row(), InitiativeModel::ColumnInitiative), value, Qt::EditRole);
+        }
+    });
+
+    connect(m_notesEdit, &QTextEdit::textChanged, this, [this]() {
+        const auto index = m_tableView->currentIndex();
+        if (index.isValid()) {
+            m_model.setData(m_model.index(index.row(), InitiativeModel::ColumnNotes), m_notesEdit->toPlainText(), Qt::EditRole);
+        }
+    });
+
+    connect(m_tableView->selectionModel(), &QItemSelectionModel::currentRowChanged, this, [this](const QModelIndex &) {
+        updateStatusBar();
+    });
+}
+
+void MainWindow::populateSampleData() {
+    TurnManager::CombatantList list;
+    for (int i = 0; i < 3; ++i) {
+        Combatant combatant;
+        combatant.id = i + 1;
+        combatant.name = QStringLiteral("Hero %1").arg(i + 1);
+        combatant.initiative = 15 - i;
+        combatant.dexMod = 3 - i;
+        combatant.isPC = true;
+        combatant.hp = 20 + i * 5;
+        list.push_back(combatant);
+    }
+    for (int i = 0; i < 3; ++i) {
+        Combatant combatant;
+        combatant.id = i + 100;
+        combatant.name = QStringLiteral("Bandit %1").arg(i + 1);
+        combatant.initiative = 12 - i;
+        combatant.dexMod = 2;
+        combatant.isPC = false;
+        combatant.hp = 12;
+        list.push_back(combatant);
+    }
+    m_turnManager.setCombatants(list);
+    m_model.refresh();
+    if (m_model.rowCount() > 0) {
+        m_tableView->selectRow(0);
+    }
+}
+
+void MainWindow::handleNextTurn() {
+    m_turnManager.advanceTurn();
+    updateStatusBar();
+}
+
+void MainWindow::handlePreviousTurn() {
+    m_turnManager.rewindTurn();
+    updateStatusBar();
+}
+
+void MainWindow::handleRollNormal() {
+    const auto index = m_tableView->currentIndex();
+    if (!index.isValid()) {
+        return;
+    }
+    auto &combatant = m_turnManager.combatants()[index.row()];
+    combatant.initiative = m_diceRoller.rollD20(RollMode::Normal, combatant.dexMod);
+    m_turnManager.sortCombatants();
+    m_model.refresh();
+}
+
+void MainWindow::handleRollAdvantage() {
+    const auto index = m_tableView->currentIndex();
+    if (!index.isValid()) {
+        return;
+    }
+    auto &combatant = m_turnManager.combatants()[index.row()];
+    combatant.initiative = m_diceRoller.rollD20(RollMode::Advantage, combatant.dexMod);
+    m_turnManager.sortCombatants();
+    m_model.refresh();
+}
+
+void MainWindow::handleRollDisadvantage() {
+    const auto index = m_tableView->currentIndex();
+    if (!index.isValid()) {
+        return;
+    }
+    auto &combatant = m_turnManager.combatants()[index.row()];
+    combatant.initiative = m_diceRoller.rollD20(RollMode::Disadvantage, combatant.dexMod);
+    m_turnManager.sortCombatants();
+    m_model.refresh();
+}
+
+void MainWindow::updateStatusBar() {
+    if (m_turnManager.combatants().isEmpty()) {
+        statusBar()->showMessage(tr("Round 0 • Turn 0/0"));
+        return;
+    }
+    const auto &current = m_turnManager.combatants().at(m_turnManager.turnIndex());
+    statusBar()->showMessage(tr("Round %1 • Turn %2/%3 • Current: %4")
+                                 .arg(m_turnManager.round())
+                                 .arg(m_turnManager.turnIndex() + 1)
+                                 .arg(m_turnManager.combatants().size())
+                                 .arg(current.name));
+}
+

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QMainWindow>
+#include <QUndoStack>
+
+#include "models/InitiativeModel.h"
+#include "models/TurnManager.h"
+#include "stores/EncounterStore.h"
+#include "stores/RosterStore.h"
+#include "undo/UndoCommands.h"
+#include "utils/DiceRoller.h"
+#include "utils/Settings.h"
+
+class QDockWidget;
+class QLineEdit;
+class QSpinBox;
+class QTextEdit;
+class QTableView;
+
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+
+private slots:
+    void handleNextTurn();
+    void handlePreviousTurn();
+    void handleRollNormal();
+    void handleRollAdvantage();
+    void handleRollDisadvantage();
+    void updateStatusBar();
+
+private:
+    void setupUi();
+    void setupMenus();
+    void connectSignals();
+    void populateSampleData();
+
+    TurnManager m_turnManager;
+    InitiativeModel m_model;
+    QUndoStack m_undoStack;
+    DiceRoller m_diceRoller;
+    Settings m_settings;
+    EncounterStore m_encounterStore;
+    RosterStore m_rosterStore;
+
+    QTableView *m_tableView = nullptr;
+    QLineEdit *m_nameEdit = nullptr;
+    QSpinBox *m_initiativeSpin = nullptr;
+    QTextEdit *m_notesEdit = nullptr;
+};
+

--- a/src/undo/UndoCommands.cpp
+++ b/src/undo/UndoCommands.cpp
@@ -1,0 +1,61 @@
+#include "UndoCommands.h"
+
+#include <algorithm>
+
+AddCombatantCommand::AddCombatantCommand(TurnManager *manager, Combatant combatant, QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , m_manager(manager)
+    , m_combatant(std::move(combatant)) {
+    setText(QObject::tr("Add %1").arg(m_combatant.name));
+}
+
+void AddCombatantCommand::undo() {
+    if (!m_manager) {
+        return;
+    }
+    m_manager->removeCombatant(m_combatant.id);
+    m_done = false;
+}
+
+void AddCombatantCommand::redo() {
+    if (!m_manager) {
+        return;
+    }
+    if (!m_done) {
+        m_manager->addCombatant(m_combatant);
+        m_done = true;
+    }
+}
+
+EditCombatantCommand::EditCombatantCommand(TurnManager *manager, int combatantId, Combatant before, Combatant after, QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , m_manager(manager)
+    , m_combatantId(combatantId)
+    , m_before(std::move(before))
+    , m_after(std::move(after)) {
+    setText(QObject::tr("Edit %1").arg(m_after.name));
+}
+
+static Combatant *findCombatant(TurnManager *manager, int id) {
+    auto &list = manager->combatants();
+    const auto it = std::find_if(list.begin(), list.end(), [id](const Combatant &c) { return c.id == id; });
+    if (it == list.end()) {
+        return nullptr;
+    }
+    return &(*it);
+}
+
+void EditCombatantCommand::undo() {
+    if (auto *combatant = findCombatant(m_manager, m_combatantId)) {
+        *combatant = m_before;
+        m_manager->sortCombatants();
+    }
+}
+
+void EditCombatantCommand::redo() {
+    if (auto *combatant = findCombatant(m_manager, m_combatantId)) {
+        *combatant = m_after;
+        m_manager->sortCombatants();
+    }
+}
+

--- a/src/undo/UndoCommands.h
+++ b/src/undo/UndoCommands.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QUndoCommand>
+
+#include "models/TurnManager.h"
+
+class AddCombatantCommand : public QUndoCommand {
+public:
+    AddCombatantCommand(TurnManager *manager, Combatant combatant, QUndoCommand *parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    TurnManager *m_manager;
+    Combatant m_combatant;
+    bool m_done = false;
+};
+
+class EditCombatantCommand : public QUndoCommand {
+public:
+    EditCombatantCommand(TurnManager *manager, int combatantId, Combatant before, Combatant after, QUndoCommand *parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    TurnManager *m_manager;
+    int m_combatantId;
+    Combatant m_before;
+    Combatant m_after;
+};
+

--- a/src/utils/DiceRoller.cpp
+++ b/src/utils/DiceRoller.cpp
@@ -1,0 +1,27 @@
+#include "DiceRoller.h"
+
+DiceRoller::DiceRoller(QObject *parent)
+    : QObject(parent)
+    , m_rng(QRandomGenerator::securelySeeded()) {}
+
+void DiceRoller::setSeed(quint32 seed) {
+    m_rng = QRandomGenerator(seed);
+}
+
+int DiceRoller::rollD20(RollMode mode, int modifier) {
+    auto rollOnce = [this]() { return static_cast<int>(m_rng.bounded(1, 21)); };
+    int first = rollOnce();
+    int result = first;
+    if (mode == RollMode::Advantage || mode == RollMode::Disadvantage) {
+        int second = rollOnce();
+        if (mode == RollMode::Advantage) {
+            result = std::max(first, second);
+        } else {
+            result = std::min(first, second);
+        }
+    }
+    int total = result + modifier;
+    emit rollPerformed(result, mode, modifier, total);
+    return total;
+}
+

--- a/src/utils/DiceRoller.h
+++ b/src/utils/DiceRoller.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QObject>
+#include <QRandomGenerator>
+
+enum class RollMode {
+    Normal,
+    Advantage,
+    Disadvantage
+};
+
+class DiceRoller : public QObject {
+    Q_OBJECT
+public:
+    explicit DiceRoller(QObject *parent = nullptr);
+
+    void setSeed(quint32 seed);
+    int rollD20(RollMode mode, int modifier = 0);
+
+signals:
+    void rollPerformed(int raw, RollMode mode, int modifier, int total);
+
+private:
+    QRandomGenerator m_rng;
+};
+

--- a/src/utils/Settings.cpp
+++ b/src/utils/Settings.cpp
@@ -1,0 +1,42 @@
+#include "Settings.h"
+
+#include <QCoreApplication>
+
+Settings::Settings(QObject *parent)
+    : QObject(parent)
+    , m_settings("OpenAI", "InitiativeTracker") {
+    m_settings.setFallbacksEnabled(true);
+}
+
+int Settings::autosaveIntervalMinutes() const {
+    return m_settings.value("autosaveInterval", 2).toInt();
+}
+
+void Settings::setAutosaveIntervalMinutes(int minutes) {
+    m_settings.setValue("autosaveInterval", minutes);
+}
+
+QString Settings::theme() const {
+    return m_settings.value("theme", "light").toString();
+}
+
+void Settings::setTheme(const QString &theme) {
+    m_settings.setValue("theme", theme);
+}
+
+bool Settings::streamerMode() const {
+    return m_settings.value("streamerMode", false).toBool();
+}
+
+void Settings::setStreamerMode(bool enabled) {
+    m_settings.setValue("streamerMode", enabled);
+}
+
+QString Settings::lastEncounterPath() const {
+    return m_settings.value("lastEncounterPath").toString();
+}
+
+void Settings::setLastEncounterPath(const QString &path) {
+    m_settings.setValue("lastEncounterPath", path);
+}
+

--- a/src/utils/Settings.h
+++ b/src/utils/Settings.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QObject>
+#include <QSettings>
+
+class Settings : public QObject {
+    Q_OBJECT
+public:
+    explicit Settings(QObject *parent = nullptr);
+
+    int autosaveIntervalMinutes() const;
+    void setAutosaveIntervalMinutes(int minutes);
+
+    QString theme() const;
+    void setTheme(const QString &theme);
+
+    bool streamerMode() const;
+    void setStreamerMode(bool enabled);
+
+    QString lastEncounterPath() const;
+    void setLastEncounterPath(const QString &path);
+
+private:
+    QSettings m_settings;
+};
+

--- a/tests/TestTurnManager.cpp
+++ b/tests/TestTurnManager.cpp
@@ -1,0 +1,113 @@
+#include <QtTest/QtTest>
+
+#include <QDir>
+
+#include "models/TurnManager.h"
+#include "stores/EncounterStore.h"
+#include "stores/RosterStore.h"
+
+class TestTurnManager : public QObject {
+    Q_OBJECT
+private slots:
+    void sortingRule();
+    void conditionDecrement();
+    void deathSavesLogic();
+    void massAddNaming();
+    void encounterRoundTrip();
+};
+
+void TestTurnManager::sortingRule() {
+    TurnManager manager;
+    Combatant a{1, "Alice", 15, 2, true};
+    Combatant b{2, "Bob", 15, 4, false};
+    Combatant c{3, "Charlie", 18, 1, false};
+    manager.addCombatant(a);
+    manager.addCombatant(b);
+    manager.addCombatant(c);
+    const auto &list = manager.combatants();
+    QCOMPARE(list[0].name, QStringLiteral("Charlie"));
+    QCOMPARE(list[1].name, QStringLiteral("Alice"));
+    QCOMPARE(list[2].name, QStringLiteral("Bob"));
+}
+
+void TestTurnManager::conditionDecrement() {
+    TurnManager manager;
+    Combatant a;
+    a.id = 1;
+    a.name = "Test";
+    a.conditions.append({"Poison", 1});
+    manager.addCombatant(a);
+    QVERIFY(manager.advanceTurn());
+    QCOMPARE(manager.combatants().first().conditions.size(), 0);
+}
+
+void TestTurnManager::deathSavesLogic() {
+    DeathSaves saves;
+    saves.recordFailure();
+    saves.recordFailure();
+    QCOMPARE(saves.failures, 2);
+    QVERIFY(!saves.dead);
+    saves.recordFailure();
+    QVERIFY(saves.dead);
+    saves.reset();
+    saves.recordSuccess();
+    saves.recordSuccess();
+    saves.recordSuccess();
+    QVERIFY(saves.stable);
+    QCOMPARE(saves.failures, 0);
+}
+
+void TestTurnManager::massAddNaming() {
+    RosterStore store;
+    MassAddNaming naming;
+    naming.pattern = "%name %index";
+    naming.startIndex = 1;
+    naming.zeroPad = true;
+    naming.width = 2;
+
+    RosterCharacter character;
+    character.name = "Bandit";
+    character.dexMod = 2;
+    character.defaultHP = 11;
+    character.defaultAC = 12;
+    character.defaultNotes = "Sneaky";
+    store.setCharacters({character});
+    store.setDefaultNaming(naming);
+
+    const auto added = store.massAdd("Bandit", 3, naming);
+    QCOMPARE(added.size(), 3);
+    QCOMPARE(added[0].name, QStringLiteral("Bandit 01"));
+    QCOMPARE(added[1].name, QStringLiteral("Bandit 02"));
+    QCOMPARE(added[2].hp, 11);
+    QCOMPARE(added[2].notes, QStringLiteral("Sneaky"));
+}
+
+void TestTurnManager::encounterRoundTrip() {
+    TurnManager manager;
+    Combatant a{1, "Alice", 15, 2, true};
+    a.hp = 25;
+    a.conditions.append({"Bless", 3});
+    manager.addCombatant(a);
+    Combatant b{2, "Bob", 12, 1, false};
+    b.conscious = false;
+    b.deathSaves.recordFailure();
+    manager.addCombatant(b);
+
+    int round = 2;
+    int turnIndex = 1;
+    const auto data = EncounterStore::serialize(manager, round, turnIndex);
+
+    TurnManager restored;
+    int restoredRound = 0;
+    int restoredTurnIndex = 0;
+    QVERIFY(EncounterStore::deserialize(data, restored, restoredRound, restoredTurnIndex));
+    QCOMPARE(restoredRound, round);
+    QCOMPARE(restoredTurnIndex, turnIndex);
+    QCOMPARE(restored.combatants().size(), manager.combatants().size());
+    QCOMPARE(restored.combatants()[0].conditions.size(), 1);
+    QCOMPARE(restored.combatants()[1].deathSaves.failures, 1);
+}
+
+QTEST_MAIN(TestTurnManager)
+#include "TestTurnManager.moc"
+


### PR DESCRIPTION
## Summary
- scaffold a Qt Widgets initiative tracker application with models, storage helpers, and GUI shell
- add JSON schema documentation, build instructions, and sample data files
- provide Qt Test unit tests covering initiative sorting, condition ticking, death saves, mass add naming, and encounter persistence

## Testing
- not run (Qt toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e10d8206f883249ce4adef1a2eef9c