### PR TITLE
Replace Qt app with console initiative engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+project(DnDInitiativeTracker LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(CTest)
+
+add_library(initiative_core
+    src/core/Combatant.cpp
+    src/core/InitiativeTracker.cpp
+    src/storage/EncounterStore.cpp
+    src/storage/RosterStore.cpp
+    src/storage/SimpleJson.cpp
+    src/utils/DiceRoller.cpp
+    src/utils/Settings.cpp
+)
+
+target_include_directories(initiative_core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+add_executable(dnd_initiative src/main.cpp)
+
+target_link_libraries(dnd_initiative PRIVATE initiative_core)
+
+add_executable(testsuite tests/TestTurnManager.cpp)
+
+target_link_libraries(testsuite PRIVATE initiative_core)
+
+add_test(NAME unit_tests COMMAND testsuite)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# D-D-initiative-tracking
+# D&D Initiative Tracker
+
+This repository provides a portable C++17 implementation of a tabletop initiative tracker focused on core combat logic, roster management, and JSON persistence. The project now targets a console-based workflow so that the underlying rules engine and storage helpers can be compiled and tested without a Qt toolchain.
+
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Run the unit tests with:
+
+```bash
+cd build
+ctest
+```
+
+You can also execute the sample console application:
+
+```bash
+./dnd_initiative
+```
+
+## Project Layout
+
+- `src/` – C++ sources for the core turn tracker, JSON stores, dice roller, and console entry point
+- `tests/` – Lightweight unit tests that exercise initiative sorting, condition ticking, death saves, roster naming, and persistence round-tripping
+- `docs/` – Additional documentation including build and schema details
+- `resources/` – Placeholder assets for future front-ends
+- `data/` – Sample JSON files for encounters, characters, and groups

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,0 +1,23 @@
+{
+  "schema": 2,
+  "characters": [
+    {
+      "name": "Vaelen",
+      "dexMod": 3,
+      "isPC": true,
+      "tags": ["pc", "paladin"],
+      "defaultHP": 38,
+      "defaultAC": 18,
+      "defaultNotes": "Aura of Protection"
+    },
+    {
+      "name": "Bandit",
+      "dexMod": 2,
+      "isPC": false,
+      "tags": ["npc", "human"],
+      "defaultHP": 11,
+      "defaultAC": 12,
+      "defaultNotes": "Pack tactics"
+    }
+  ]
+}

--- a/data/groups.json
+++ b/data/groups.json
@@ -1,0 +1,23 @@
+{
+  "schema": 2,
+  "groups": [
+    {
+      "name": "Bandit Ambush",
+      "entries": [
+        {"character": "Bandit", "count": 4}
+      ]
+    },
+    {
+      "name": "Heroes",
+      "entries": [
+        {"character": "Vaelen", "count": 1}
+      ]
+    }
+  ],
+  "naming": {
+    "pattern": "%name %index",
+    "startIndex": 1,
+    "zeroPad": true,
+    "width": 2
+  }
+}

--- a/data/sample_encounter.json
+++ b/data/sample_encounter.json
@@ -1,0 +1,33 @@
+{
+  "schema": 2,
+  "round": 1,
+  "turnIndex": 0,
+  "combatants": [
+    {
+      "id": 1,
+      "name": "Vaelen",
+      "initiative": 18,
+      "dexMod": 3,
+      "isPC": true,
+      "conscious": true,
+      "hp": 38,
+      "ac": 18,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [{"name": "Bless", "remainingRounds": 8}],
+      "notes": "Protect the wizard"
+    },
+    {
+      "id": 2,
+      "name": "Bandit 01",
+      "initiative": 14,
+      "dexMod": 2,
+      "isPC": false,
+      "conscious": true,
+      "hp": 11,
+      "ac": 12,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [],
+      "notes": ""
+    }
+  ]
+}

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,25 @@
+# Build and Deployment Notes
+
+## Prerequisites
+
+- CMake 3.16+
+- A C++17 compiler
+
+The project is self-contained and does not rely on Qt or third-party package managers. All JSON parsing, persistence helpers, and tests are implemented in the repository.
+
+## Configure and Build
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+### Running
+
+From the build directory run the console prototype:
+
+```bash
+./dnd_initiative
+```
+
+The executable demonstrates loading the sample encounter, advancing turns, generating mass-added roster entries, and rolling initiative with advantage.

--- a/docs/JSON.md
+++ b/docs/JSON.md
@@ -1,0 +1,68 @@
+# JSON Schemas
+
+## Encounter (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "round": 1,
+  "turnIndex": 0,
+  "combatants": [
+    {
+      "id": 1,
+      "name": "Vaelen",
+      "initiative": 17,
+      "dexMod": 3,
+      "isPC": true,
+      "conscious": true,
+      "hp": 27,
+      "ac": 17,
+      "deathSaves": {"successes": 0, "failures": 0, "dead": false, "stable": false},
+      "conditions": [{"name": "Bless", "remainingRounds": 8}],
+      "notes": "Focus fire on the wight."
+    }
+  ]
+}
+```
+
+## Characters (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "characters": [
+    {
+      "name": "Bandit",
+      "dexMod": 2,
+      "isPC": false,
+      "tags": ["human", "bandit"],
+      "defaultHP": 11,
+      "defaultAC": 12,
+      "defaultNotes": ""
+    }
+  ]
+}
+```
+
+## Groups (`schema = 2`)
+
+```json
+{
+  "schema": 2,
+  "groups": [
+    {
+      "name": "Bandits x6",
+      "entries": [
+        {"character": "Bandit", "count": 6}
+      ]
+    }
+  ],
+  "naming": {
+    "pattern": "%name %index",
+    "startIndex": 1,
+    "zeroPad": true,
+    "width": 2
+  }
+}
+```
+

--- a/resources/icons/README.md
+++ b/resources/icons/README.md
@@ -1,0 +1,1 @@
+Placeholder directory for application icons.

--- a/resources/themes/dark.qss
+++ b/resources/themes/dark.qss
@@ -1,0 +1,3 @@
+/* Placeholder dark theme */
+QMainWindow { background: #1e1e1e; color: #f0f0f0; }
+QTableView { background: #2b2b2b; color: #f0f0f0; gridline-color: #444; }

--- a/resources/themes/light.qss
+++ b/resources/themes/light.qss
@@ -1,0 +1,3 @@
+/* Placeholder light theme */
+QMainWindow { background: #f7f7f7; }
+QTableView { gridline-color: #d0d0d0; }

--- a/src/core/Combatant.cpp
+++ b/src/core/Combatant.cpp
@@ -1,0 +1,53 @@
+#include "core/Combatant.h"
+
+#include <algorithm>
+
+namespace initiative {
+
+namespace {
+constexpr int kMaxDeathSaveCount = 3;
+}
+
+void DeathSaves::addSuccess() {
+    if (dead) {
+        return;
+    }
+    successes = std::min(successes + 1, kMaxDeathSaveCount);
+    if (successes >= kMaxDeathSaveCount) {
+        stable = true;
+    }
+}
+
+void DeathSaves::addFailure() {
+    if (stable) {
+        return;
+    }
+    failures = std::min(failures + 1, kMaxDeathSaveCount);
+    if (failures >= kMaxDeathSaveCount) {
+        dead = true;
+    }
+}
+
+void DeathSaves::reset() {
+    successes = 0;
+    failures = 0;
+    dead = false;
+    stable = false;
+}
+
+void decrementConditions(Combatant& combatant) {
+    for (auto& condition : combatant.conditions) {
+        if (condition.remainingRounds > 0) {
+            --condition.remainingRounds;
+        }
+    }
+
+    auto remover = [](const Condition& condition) {
+        return condition.remainingRounds <= 0;
+    };
+    combatant.conditions.erase(
+        std::remove_if(combatant.conditions.begin(), combatant.conditions.end(), remover),
+        combatant.conditions.end());
+}
+
+}

--- a/src/core/Combatant.h
+++ b/src/core/Combatant.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace initiative {
+
+struct Condition {
+    std::string name;
+    int remainingRounds{0};
+};
+
+struct DeathSaves {
+    int successes{0};
+    int failures{0};
+    bool dead{false};
+    bool stable{false};
+
+    void addSuccess();
+    void addFailure();
+    void reset();
+};
+
+struct Combatant {
+    int id{0};
+    std::string name;
+    int initiative{0};
+    int dexMod{0};
+    bool isPC{false};
+    bool conscious{true};
+    int hp{0};
+    int ac{0};
+    DeathSaves deathSaves;
+    std::vector<Condition> conditions;
+    std::string notes;
+};
+
+void decrementConditions(Combatant& combatant);
+
+}

--- a/src/core/InitiativeTracker.cpp
+++ b/src/core/InitiativeTracker.cpp
@@ -1,0 +1,173 @@
+#include "core/InitiativeTracker.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace initiative {
+
+namespace {
+std::string toLower(const std::string& value) {
+    std::string copy = value;
+    std::transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return copy;
+}
+}
+
+void InitiativeTracker::setCombatants(std::vector<Combatant> combatants) {
+    combatants_ = std::move(combatants);
+    sortCombatants();
+    currentIndex_.reset();
+    ensureIndex();
+}
+
+void InitiativeTracker::addCombatant(const Combatant& combatant) {
+    combatants_.push_back(combatant);
+    sortCombatants();
+}
+
+std::vector<Combatant>& InitiativeTracker::combatants() {
+    return combatants_;
+}
+
+const std::vector<Combatant>& InitiativeTracker::combatants() const {
+    return combatants_;
+}
+
+void InitiativeTracker::sortCombatants() {
+    std::sort(combatants_.begin(), combatants_.end(), compareCombatants);
+    if (!combatants_.empty()) {
+        ensureIndex();
+    } else {
+        currentIndex_.reset();
+    }
+}
+
+std::optional<std::size_t> InitiativeTracker::currentIndex() const {
+    return currentIndex_;
+}
+
+Combatant* InitiativeTracker::currentCombatant() {
+    if (!currentIndex_) {
+        return nullptr;
+    }
+    return &combatants_.at(*currentIndex_);
+}
+
+const Combatant* InitiativeTracker::currentCombatant() const {
+    if (!currentIndex_) {
+        return nullptr;
+    }
+    return &combatants_.at(*currentIndex_);
+}
+
+int InitiativeTracker::currentRound() const {
+    return round_;
+}
+
+void InitiativeTracker::setRound(int round) {
+    round_ = std::max(1, round);
+}
+
+void InitiativeTracker::nextTurn(bool skipUnconscious) {
+    if (combatants_.empty()) {
+        return;
+    }
+
+    ensureIndex();
+    if (!currentIndex_) {
+        return;
+    }
+
+    decrementConditions(combatants_.at(*currentIndex_));
+    stepForward(skipUnconscious);
+}
+
+void InitiativeTracker::previousTurn(bool skipUnconscious) {
+    if (combatants_.empty()) {
+        return;
+    }
+
+    ensureIndex();
+    if (!currentIndex_) {
+        return;
+    }
+
+    stepBackward(skipUnconscious);
+}
+
+bool InitiativeTracker::compareCombatants(const Combatant& lhs, const Combatant& rhs) {
+    if (lhs.initiative != rhs.initiative) {
+        return lhs.initiative > rhs.initiative;
+    }
+    if (lhs.dexMod != rhs.dexMod) {
+        return lhs.dexMod > rhs.dexMod;
+    }
+    if (lhs.isPC != rhs.isPC) {
+        return lhs.isPC && !rhs.isPC;
+    }
+    return toLower(lhs.name) < toLower(rhs.name);
+}
+
+void InitiativeTracker::ensureIndex() {
+    if (combatants_.empty()) {
+        currentIndex_.reset();
+        return;
+    }
+    if (!currentIndex_) {
+        currentIndex_ = 0;
+        if (combatants_.at(*currentIndex_).conscious) {
+            return;
+        }
+        stepForward(true);
+    }
+}
+
+void InitiativeTracker::stepForward(bool skipUnconscious) {
+    if (combatants_.empty()) {
+        currentIndex_.reset();
+        return;
+    }
+
+    const std::size_t originalIndex = currentIndex_.value_or(0);
+    std::size_t index = originalIndex;
+
+    do {
+        index = (index + 1) % combatants_.size();
+        if (index == 0 && index != originalIndex) {
+            ++round_;
+        }
+        if (!skipUnconscious || combatants_.at(index).conscious) {
+            currentIndex_ = index;
+            return;
+        }
+    } while (index != originalIndex);
+
+    currentIndex_ = index;
+}
+
+void InitiativeTracker::stepBackward(bool skipUnconscious) {
+    if (combatants_.empty()) {
+        currentIndex_.reset();
+        return;
+    }
+
+    const std::size_t originalIndex = currentIndex_.value_or(0);
+    std::size_t index = originalIndex;
+
+    do {
+        index = (index + combatants_.size() - 1) % combatants_.size();
+        if (index == combatants_.size() - 1 && index != originalIndex) {
+            round_ = std::max(1, round_ - 1);
+        }
+        if (!skipUnconscious || combatants_.at(index).conscious) {
+            currentIndex_ = index;
+            return;
+        }
+    } while (index != originalIndex);
+
+    currentIndex_ = index;
+}
+
+}

--- a/src/core/InitiativeTracker.h
+++ b/src/core/InitiativeTracker.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/Combatant.h"
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace initiative {
+
+class InitiativeTracker {
+public:
+    void setCombatants(std::vector<Combatant> combatants);
+    void addCombatant(const Combatant& combatant);
+
+    std::vector<Combatant>& combatants();
+    const std::vector<Combatant>& combatants() const;
+
+    void sortCombatants();
+
+    std::optional<std::size_t> currentIndex() const;
+    Combatant* currentCombatant();
+    const Combatant* currentCombatant() const;
+
+    int currentRound() const;
+    void setRound(int round);
+
+    void nextTurn(bool skipUnconscious = true);
+    void previousTurn(bool skipUnconscious = true);
+
+private:
+    static bool compareCombatants(const Combatant& lhs, const Combatant& rhs);
+    void ensureIndex();
+    void stepForward(bool skipUnconscious);
+    void stepBackward(bool skipUnconscious);
+
+    std::vector<Combatant> combatants_;
+    std::optional<std::size_t> currentIndex_;
+    int round_{1};
+};
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,51 @@
+#include "core/InitiativeTracker.h"
+#include "storage/EncounterStore.h"
+#include "storage/RosterStore.h"
+#include "utils/DiceRoller.h"
+
+#include <filesystem>
+#include <iostream>
+
+int main() {
+    using namespace initiative;
+
+    std::cout << "D&D Initiative Tracker (console prototype)" << std::endl;
+
+    try {
+        const std::filesystem::path encounterPath{"data/sample_encounter.json"};
+        EncounterData encounter = EncounterStore::loadFromFile(encounterPath);
+
+        InitiativeTracker tracker;
+        tracker.setCombatants(encounter.combatants);
+        tracker.setRound(encounter.round);
+
+        if (auto current = tracker.currentCombatant()) {
+            std::cout << "Round " << tracker.currentRound() << ": " << current->name << " acts first." << std::endl;
+        }
+
+        tracker.nextTurn();
+        if (auto current = tracker.currentCombatant()) {
+            std::cout << "Next up: " << current->name << std::endl;
+        }
+
+        RosterStore roster;
+        roster.loadCharacters("data/characters.json");
+        roster.loadGroups("data/groups.json");
+
+        int nextId = 100;
+        auto bandits = roster.instantiateGroup("Bandit Ambush", nextId);
+        std::cout << "Loaded roster group with " << bandits.size() << " combatants:" << std::endl;
+        for (const auto& combatant : bandits) {
+            std::cout << "  - " << combatant.name << " (DEX " << combatant.dexMod << ")" << std::endl;
+        }
+
+        DiceRoller roller{12345};
+        const int roll = roller.rollInitiative(3, DiceRoller::Mode::Advantage);
+        std::cout << "Sample initiative roll (advantage, DEX +3): " << roll << std::endl;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/storage/EncounterStore.cpp
+++ b/src/storage/EncounterStore.cpp
@@ -1,0 +1,122 @@
+#include "storage/EncounterStore.h"
+
+#include "storage/SimpleJson.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace initiative {
+
+namespace {
+using simplejson::JsonValue;
+
+Combatant parseCombatant(const JsonValue& value) {
+    const auto& object = value.asObject();
+    Combatant combatant;
+    combatant.id = object.at("id").asInt();
+    combatant.name = object.at("name").asString();
+    combatant.initiative = object.at("initiative").asInt();
+    combatant.dexMod = object.at("dexMod").asInt();
+    combatant.isPC = object.at("isPC").asBool();
+    combatant.conscious = object.at("conscious").asBool();
+    combatant.hp = object.at("hp").asInt();
+    combatant.ac = object.at("ac").asInt();
+    if (value.contains("notes")) {
+        combatant.notes = value.at("notes").asString();
+    }
+    if (value.contains("deathSaves")) {
+        const auto& savesObj = value.at("deathSaves").asObject();
+        combatant.deathSaves.successes = savesObj.at("successes").asInt();
+        combatant.deathSaves.failures = savesObj.at("failures").asInt();
+        combatant.deathSaves.dead = savesObj.at("dead").asBool();
+        combatant.deathSaves.stable = savesObj.at("stable").asBool();
+    }
+    if (value.contains("conditions")) {
+        for (const auto& conditionValue : value.at("conditions").asArray()) {
+            const auto& conditionObj = conditionValue.asObject();
+            combatant.conditions.push_back({conditionObj.at("name").asString(),
+                                            static_cast<int>(conditionObj.at("remainingRounds").asInt())});
+        }
+    }
+    return combatant;
+}
+
+JsonValue serializeCombatant(const Combatant& combatant) {
+    JsonValue::Object object;
+    object.emplace("id", JsonValue(static_cast<int64_t>(combatant.id)));
+    object.emplace("name", JsonValue(combatant.name));
+    object.emplace("initiative", JsonValue(static_cast<int64_t>(combatant.initiative)));
+    object.emplace("dexMod", JsonValue(static_cast<int64_t>(combatant.dexMod)));
+    object.emplace("isPC", JsonValue(combatant.isPC));
+    object.emplace("conscious", JsonValue(combatant.conscious));
+    object.emplace("hp", JsonValue(static_cast<int64_t>(combatant.hp)));
+    object.emplace("ac", JsonValue(static_cast<int64_t>(combatant.ac)));
+    object.emplace("notes", JsonValue(combatant.notes));
+
+    JsonValue::Object savesObj;
+    savesObj.emplace("successes", JsonValue(static_cast<int64_t>(combatant.deathSaves.successes)));
+    savesObj.emplace("failures", JsonValue(static_cast<int64_t>(combatant.deathSaves.failures)));
+    savesObj.emplace("dead", JsonValue(combatant.deathSaves.dead));
+    savesObj.emplace("stable", JsonValue(combatant.deathSaves.stable));
+    object.emplace("deathSaves", JsonValue(std::move(savesObj)));
+
+    JsonValue::Array conditionsArray;
+    for (const auto& condition : combatant.conditions) {
+        JsonValue::Object conditionObj;
+        conditionObj.emplace("name", JsonValue(condition.name));
+        conditionObj.emplace("remainingRounds", JsonValue(static_cast<int64_t>(condition.remainingRounds)));
+        conditionsArray.emplace_back(JsonValue(std::move(conditionObj)));
+    }
+    object.emplace("conditions", JsonValue(std::move(conditionsArray)));
+
+    return JsonValue(std::move(object));
+}
+}
+
+EncounterData EncounterStore::loadFromFile(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input) {
+        throw std::runtime_error("Unable to open encounter file: " + path.string());
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    JsonValue data = simplejson::parse(buffer.str());
+    const auto& object = data.asObject();
+
+    EncounterData encounter;
+    encounter.schema = static_cast<int>(object.at("schema").asInt());
+    if (encounter.schema != 2) {
+        throw std::runtime_error("Unsupported encounter schema");
+    }
+    encounter.round = static_cast<int>(object.at("round").asInt());
+    encounter.turnIndex = static_cast<std::size_t>(object.at("turnIndex").asInt());
+    if (data.contains("combatants")) {
+        for (const auto& value : data.at("combatants").asArray()) {
+            encounter.combatants.push_back(parseCombatant(value));
+        }
+    }
+    return encounter;
+}
+
+void EncounterStore::saveToFile(const EncounterData& encounter, const std::filesystem::path& path) {
+    JsonValue::Object object;
+    object.emplace("schema", JsonValue(static_cast<int64_t>(encounter.schema)));
+    object.emplace("round", JsonValue(static_cast<int64_t>(encounter.round)));
+    object.emplace("turnIndex", JsonValue(static_cast<int64_t>(encounter.turnIndex)));
+
+    JsonValue::Array combatantArray;
+    for (const auto& combatant : encounter.combatants) {
+        combatantArray.emplace_back(serializeCombatant(combatant));
+    }
+    object.emplace("combatants", JsonValue(std::move(combatantArray)));
+
+    std::ofstream output(path);
+    if (!output) {
+        throw std::runtime_error("Unable to write encounter file: " + path.string());
+    }
+    output << simplejson::stringify(JsonValue(std::move(object)), 2);
+}
+
+}

--- a/src/storage/EncounterStore.h
+++ b/src/storage/EncounterStore.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "core/Combatant.h"
+
+#include <filesystem>
+#include <vector>
+
+namespace initiative {
+
+struct EncounterData {
+    int schema{2};
+    int round{1};
+    std::size_t turnIndex{0};
+    std::vector<Combatant> combatants;
+};
+
+class EncounterStore {
+public:
+    static EncounterData loadFromFile(const std::filesystem::path& path);
+    static void saveToFile(const EncounterData& encounter, const std::filesystem::path& path);
+};
+
+}

--- a/src/storage/RosterStore.cpp
+++ b/src/storage/RosterStore.cpp
@@ -1,0 +1,224 @@
+#include "storage/RosterStore.h"
+
+#include "storage/SimpleJson.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+namespace initiative {
+
+namespace {
+using simplejson::JsonValue;
+
+Character parseCharacter(const JsonValue& value) {
+    const auto& object = value.asObject();
+    Character character;
+    character.name = object.at("name").asString();
+    character.dexMod = static_cast<int>(object.at("dexMod").asInt());
+    character.isPC = object.at("isPC").asBool();
+    if (value.contains("tags")) {
+        for (const auto& tag : value.at("tags").asArray()) {
+            character.tags.push_back(tag.asString());
+        }
+    }
+    if (value.contains("defaultHP")) {
+        character.defaultHP = static_cast<int>(value.at("defaultHP").asInt());
+    }
+    if (value.contains("defaultAC")) {
+        character.defaultAC = static_cast<int>(value.at("defaultAC").asInt());
+    }
+    if (value.contains("defaultNotes")) {
+        character.defaultNotes = value.at("defaultNotes").asString();
+    }
+    return character;
+}
+
+Group parseGroup(const JsonValue& value) {
+    const auto& object = value.asObject();
+    Group group;
+    group.name = object.at("name").asString();
+    if (value.contains("entries")) {
+        for (const auto& entryValue : value.at("entries").asArray()) {
+            const auto& entryObj = entryValue.asObject();
+            GroupEntry entry;
+            entry.character = entryObj.at("character").asString();
+            if (entryValue.contains("count")) {
+                entry.count = static_cast<int>(entryObj.at("count").asInt());
+            }
+            group.entries.push_back(std::move(entry));
+        }
+    }
+    return group;
+}
+
+NamingOptions parseNamingOptions(const JsonValue& value) {
+    const auto& object = value.asObject();
+    NamingOptions options;
+    if (value.contains("pattern")) {
+        options.pattern = value.at("pattern").asString();
+    }
+    if (value.contains("startIndex")) {
+        options.startIndex = static_cast<int>(value.at("startIndex").asInt());
+    }
+    if (value.contains("zeroPad")) {
+        options.zeroPad = value.at("zeroPad").asBool();
+    }
+    if (value.contains("width")) {
+        options.width = static_cast<int>(value.at("width").asInt());
+    }
+    return options;
+}
+
+std::string formatIndex(int value, const NamingOptions& options) {
+    if (!options.zeroPad) {
+        return std::to_string(value);
+    }
+    const int width = options.width > 0 ? options.width : 2;
+    std::ostringstream oss;
+    oss << std::setfill('0') << std::setw(width) << value;
+    return oss.str();
+}
+
+std::string applyPattern(const NamingOptions& options, const std::string& baseName, int index) {
+    std::string result = options.pattern;
+    const std::string indexValue = formatIndex(index, options);
+
+    std::size_t pos = 0;
+    while ((pos = result.find("%name", pos)) != std::string::npos) {
+        result.replace(pos, 5, baseName);
+        pos += baseName.size();
+    }
+
+    pos = 0;
+    while ((pos = result.find("%index", pos)) != std::string::npos) {
+        result.replace(pos, 6, indexValue);
+        pos += indexValue.size();
+    }
+
+    return result;
+}
+}
+
+void RosterStore::loadCharacters(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input) {
+        throw std::runtime_error("Unable to open characters file: " + path.string());
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    JsonValue data = simplejson::parse(buffer.str());
+    const auto& object = data.asObject();
+
+    if (data.contains("schema") && data.at("schema").asInt() != 2) {
+        throw std::runtime_error("Unsupported character schema");
+    }
+
+    characters_.clear();
+    characterLookup_.clear();
+    if (data.contains("characters")) {
+        for (const auto& value : data.at("characters").asArray()) {
+            auto character = parseCharacter(value);
+            characterLookup_.emplace(character.name, character);
+            characters_.push_back(std::move(character));
+        }
+    }
+}
+
+void RosterStore::loadGroups(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input) {
+        throw std::runtime_error("Unable to open groups file: " + path.string());
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    JsonValue data = simplejson::parse(buffer.str());
+    const auto& object = data.asObject();
+
+    if (data.contains("schema") && data.at("schema").asInt() != 2) {
+        throw std::runtime_error("Unsupported group schema");
+    }
+
+    groups_.clear();
+    if (data.contains("groups")) {
+        for (const auto& value : data.at("groups").asArray()) {
+            groups_.push_back(parseGroup(value));
+        }
+    }
+    if (data.contains("naming")) {
+        namingOptions_ = parseNamingOptions(data.at("naming"));
+    }
+}
+
+const std::vector<Character>& RosterStore::characters() const {
+    return characters_;
+}
+
+const std::vector<Group>& RosterStore::groups() const {
+    return groups_;
+}
+
+const NamingOptions& RosterStore::namingOptions() const {
+    return namingOptions_;
+}
+
+std::vector<Character> RosterStore::filterByTag(const std::string& tag) const {
+    std::vector<Character> matches;
+    for (const auto& character : characters_) {
+        if (std::find(character.tags.begin(), character.tags.end(), tag) != character.tags.end()) {
+            matches.push_back(character);
+        }
+    }
+    return matches;
+}
+
+std::optional<Character> RosterStore::findCharacter(const std::string& name) const {
+    if (auto it = characterLookup_.find(name); it != characterLookup_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::vector<Combatant> RosterStore::instantiateGroup(const std::string& groupName, int& nextId) const {
+    auto groupIt = std::find_if(groups_.begin(), groups_.end(), [&](const Group& group) {
+        return group.name == groupName;
+    });
+
+    if (groupIt == groups_.end()) {
+        throw std::runtime_error("Group not found: " + groupName);
+    }
+
+    std::vector<Combatant> result;
+    for (const auto& entry : groupIt->entries) {
+        auto character = findCharacter(entry.character);
+        if (!character) {
+            throw std::runtime_error("Character not found: " + entry.character);
+        }
+        int indexValue = namingOptions_.startIndex;
+        for (int offset = 0; offset < entry.count; ++offset) {
+            const int index = indexValue++;
+            const std::string name = applyPattern(namingOptions_, character->name, index);
+            result.push_back(instantiateCharacter(*character, name, nextId));
+        }
+    }
+    return result;
+}
+
+Combatant RosterStore::instantiateCharacter(const Character& character, const std::string& nameOverride, int& nextId) const {
+    Combatant combatant;
+    combatant.id = nextId++;
+    combatant.name = nameOverride;
+    combatant.dexMod = character.dexMod;
+    combatant.isPC = character.isPC;
+    combatant.conscious = true;
+    combatant.hp = character.defaultHP;
+    combatant.ac = character.defaultAC;
+    combatant.notes = character.defaultNotes;
+    return combatant;
+}
+
+}

--- a/src/storage/RosterStore.h
+++ b/src/storage/RosterStore.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "core/Combatant.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace initiative {
+
+struct Character {
+    std::string name;
+    int dexMod{0};
+    bool isPC{false};
+    std::vector<std::string> tags;
+    int defaultHP{0};
+    int defaultAC{0};
+    std::string defaultNotes;
+};
+
+struct GroupEntry {
+    std::string character;
+    int count{1};
+};
+
+struct Group {
+    std::string name;
+    std::vector<GroupEntry> entries;
+};
+
+struct NamingOptions {
+    std::string pattern{"%name %index"};
+    int startIndex{1};
+    bool zeroPad{false};
+    int width{2};
+};
+
+class RosterStore {
+public:
+    void loadCharacters(const std::filesystem::path& path);
+    void loadGroups(const std::filesystem::path& path);
+
+    const std::vector<Character>& characters() const;
+    const std::vector<Group>& groups() const;
+    const NamingOptions& namingOptions() const;
+
+    std::vector<Character> filterByTag(const std::string& tag) const;
+    std::optional<Character> findCharacter(const std::string& name) const;
+    std::vector<Combatant> instantiateGroup(const std::string& groupName, int& nextId) const;
+
+private:
+    Combatant instantiateCharacter(const Character& character, const std::string& nameOverride, int& nextId) const;
+
+    std::vector<Character> characters_;
+    std::vector<Group> groups_;
+    NamingOptions namingOptions_;
+    std::unordered_map<std::string, Character> characterLookup_;
+};
+
+}

--- a/src/storage/SimpleJson.cpp
+++ b/src/storage/SimpleJson.cpp
@@ -1,0 +1,420 @@
+#include "storage/SimpleJson.h"
+
+#include <charconv>
+#include <cctype>
+#include <sstream>
+
+namespace simplejson {
+
+namespace {
+class Parser {
+public:
+    explicit Parser(std::string_view text)
+        : text_(text) {}
+
+    JsonValue parse() {
+        skipWhitespace();
+        JsonValue value = parseValue();
+        skipWhitespace();
+        if (!isAtEnd()) {
+            throw std::runtime_error("Unexpected trailing characters in JSON");
+        }
+        return value;
+    }
+
+private:
+    JsonValue parseValue() {
+        if (isAtEnd()) {
+            throw std::runtime_error("Unexpected end of JSON");
+        }
+        char ch = peek();
+        if (ch == '"') {
+            return JsonValue(parseString());
+        }
+        if (ch == '{') {
+            return JsonValue(parseObject());
+        }
+        if (ch == '[') {
+            return JsonValue(parseArray());
+        }
+        if (ch == 't') {
+            consumeLiteral("true");
+            return JsonValue(true);
+        }
+        if (ch == 'f') {
+            consumeLiteral("false");
+            return JsonValue(false);
+        }
+        if (ch == 'n') {
+            consumeLiteral("null");
+            return JsonValue(nullptr);
+        }
+        if (ch == '-' || std::isdigit(static_cast<unsigned char>(ch))) {
+            return JsonValue(parseNumber());
+        }
+        throw std::runtime_error("Invalid JSON token");
+    }
+
+    JsonValue::Object parseObject() {
+        expect('{');
+        skipWhitespace();
+        JsonValue::Object object;
+        if (match('}')) {
+            return object;
+        }
+        while (true) {
+            skipWhitespace();
+            std::string key = parseString();
+            skipWhitespace();
+            expect(':');
+            skipWhitespace();
+            object.emplace(std::move(key), parseValue());
+            skipWhitespace();
+            if (match('}')) {
+                break;
+            }
+            expect(',');
+            skipWhitespace();
+        }
+        return object;
+    }
+
+    JsonValue::Array parseArray() {
+        expect('[');
+        skipWhitespace();
+        JsonValue::Array array;
+        if (match(']')) {
+            return array;
+        }
+        while (true) {
+            skipWhitespace();
+            array.push_back(parseValue());
+            skipWhitespace();
+            if (match(']')) {
+                break;
+            }
+            expect(',');
+            skipWhitespace();
+        }
+        return array;
+    }
+
+    std::string parseString() {
+        expect('"');
+        std::string result;
+        while (!isAtEnd()) {
+            char ch = advance();
+            if (ch == '"') {
+                return result;
+            }
+            if (ch == '\\') {
+                if (isAtEnd()) {
+                    throw std::runtime_error("Invalid escape sequence");
+                }
+                char escape = advance();
+                switch (escape) {
+                    case '"': result.push_back('"'); break;
+                    case '\\': result.push_back('\\'); break;
+                    case '/': result.push_back('/'); break;
+                    case 'b': result.push_back('\b'); break;
+                    case 'f': result.push_back('\f'); break;
+                    case 'n': result.push_back('\n'); break;
+                    case 'r': result.push_back('\r'); break;
+                    case 't': result.push_back('\t'); break;
+                    default:
+                        throw std::runtime_error("Unsupported escape sequence");
+                }
+            } else {
+                result.push_back(ch);
+            }
+        }
+        throw std::runtime_error("Unterminated string literal");
+    }
+
+    int64_t parseNumber() {
+        std::size_t start = index_;
+        if (match('-')) {
+            // allow negative numbers
+        }
+        if (match('0')) {
+            // leading zero allowed only for zero
+        } else {
+            while (!isAtEnd() && std::isdigit(static_cast<unsigned char>(peek()))) {
+                advance();
+            }
+        }
+        std::string_view slice = text_.substr(start, index_ - start);
+        int64_t value = 0;
+        auto [ptr, ec] = std::from_chars(slice.data(), slice.data() + slice.size(), value);
+        if (ec != std::errc()) {
+            throw std::runtime_error("Invalid numeric value in JSON");
+        }
+        return value;
+    }
+
+    void consumeLiteral(std::string_view literal) {
+        for (char expected : literal) {
+            if (isAtEnd() || advance() != expected) {
+                throw std::runtime_error("Invalid JSON literal");
+            }
+        }
+    }
+
+    void skipWhitespace() {
+        while (!isAtEnd()) {
+            char ch = peek();
+            if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+                advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    void expect(char expected) {
+        if (isAtEnd() || advance() != expected) {
+            throw std::runtime_error("Unexpected character in JSON");
+        }
+    }
+
+    bool match(char expected) {
+        if (isAtEnd() || text_[index_] != expected) {
+            return false;
+        }
+        ++index_;
+        return true;
+    }
+
+    char peek() const {
+        return text_[index_];
+    }
+
+    char advance() {
+        return text_[index_++];
+    }
+
+    bool isAtEnd() const {
+        return index_ >= text_.size();
+    }
+
+    std::string_view text_;
+    std::size_t index_{0};
+};
+
+std::string escapeString(const std::string& value) {
+    std::string result;
+    for (char ch : value) {
+        switch (ch) {
+            case '\\': result += "\\\\"; break;
+            case '\"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result.push_back(ch); break;
+        }
+    }
+    return result;
+}
+
+std::string stringifyImpl(const JsonValue& value, int indentSize, int depth) {
+    const std::string indent(depth * indentSize, ' ');
+    const std::string childIndent((depth + 1) * indentSize, ' ');
+
+    if (value.isNull()) {
+        return "null";
+    }
+    if (value.isBool()) {
+        return value.asBool() ? "true" : "false";
+    }
+    if (value.isNumber()) {
+        return std::to_string(value.asInt());
+    }
+    if (value.isString()) {
+        return '"' + escapeString(value.asString()) + '"';
+    }
+    if (value.isArray()) {
+        const auto& array = value.asArray();
+        if (array.empty()) {
+            return "[]";
+        }
+        std::ostringstream oss;
+        oss << "[\n";
+        for (std::size_t i = 0; i < array.size(); ++i) {
+            oss << childIndent << stringifyImpl(array[i], indentSize, depth + 1);
+            if (i + 1 < array.size()) {
+                oss << ",\n";
+            } else {
+                oss << "\n";
+            }
+        }
+        oss << indent << "]";
+        return oss.str();
+    }
+
+    const auto& object = value.asObject();
+    if (object.empty()) {
+        return "{}";
+    }
+    std::ostringstream oss;
+    oss << "{\n";
+    std::size_t index = 0;
+    for (const auto& [key, child] : object) {
+        oss << childIndent << "\"" << escapeString(key) << "\": "
+            << stringifyImpl(child, indentSize, depth + 1);
+        if (index + 1 < object.size()) {
+            oss << ",\n";
+        } else {
+            oss << "\n";
+        }
+        ++index;
+    }
+    oss << indent << "}";
+    return oss.str();
+}
+}
+
+JsonValue::JsonValue()
+    : value_(nullptr) {}
+
+JsonValue::JsonValue(std::nullptr_t)
+    : value_(nullptr) {}
+
+JsonValue::JsonValue(bool value)
+    : value_(value) {}
+
+JsonValue::JsonValue(int64_t value)
+    : value_(value) {}
+
+JsonValue::JsonValue(std::string value)
+    : value_(std::move(value)) {}
+
+JsonValue::JsonValue(const char* value)
+    : value_(std::string(value)) {}
+
+JsonValue::JsonValue(Array value)
+    : value_(std::move(value)) {}
+
+JsonValue::JsonValue(Object value)
+    : value_(std::move(value)) {}
+
+bool JsonValue::isNull() const {
+    return std::holds_alternative<std::nullptr_t>(value_);
+}
+
+bool JsonValue::isBool() const {
+    return std::holds_alternative<bool>(value_);
+}
+
+bool JsonValue::isNumber() const {
+    return std::holds_alternative<int64_t>(value_);
+}
+
+bool JsonValue::isString() const {
+    return std::holds_alternative<std::string>(value_);
+}
+
+bool JsonValue::isArray() const {
+    return std::holds_alternative<Array>(value_);
+}
+
+bool JsonValue::isObject() const {
+    return std::holds_alternative<Object>(value_);
+}
+
+bool JsonValue::asBool() const {
+    if (!isBool()) {
+        throw std::runtime_error("JSON value is not a boolean");
+    }
+    return std::get<bool>(value_);
+}
+
+int64_t JsonValue::asInt() const {
+    if (!isNumber()) {
+        throw std::runtime_error("JSON value is not a number");
+    }
+    return std::get<int64_t>(value_);
+}
+
+const std::string& JsonValue::asString() const {
+    if (!isString()) {
+        throw std::runtime_error("JSON value is not a string");
+    }
+    return std::get<std::string>(value_);
+}
+
+const JsonValue::Array& JsonValue::asArray() const {
+    if (!isArray()) {
+        throw std::runtime_error("JSON value is not an array");
+    }
+    return std::get<Array>(value_);
+}
+
+JsonValue::Array& JsonValue::asArray() {
+    if (!isArray()) {
+        throw std::runtime_error("JSON value is not an array");
+    }
+    return std::get<Array>(value_);
+}
+
+const JsonValue::Object& JsonValue::asObject() const {
+    if (!isObject()) {
+        throw std::runtime_error("JSON value is not an object");
+    }
+    return std::get<Object>(value_);
+}
+
+JsonValue::Object& JsonValue::asObject() {
+    if (!isObject()) {
+        throw std::runtime_error("JSON value is not an object");
+    }
+    return std::get<Object>(value_);
+}
+
+bool JsonValue::contains(const std::string& key) const {
+    if (!isObject()) {
+        return false;
+    }
+    const auto& object = std::get<Object>(value_);
+    return object.find(key) != object.end();
+}
+
+const JsonValue& JsonValue::at(const std::string& key) const {
+    if (!isObject()) {
+        throw std::runtime_error("JSON value is not an object");
+    }
+    const auto& object = std::get<Object>(value_);
+    if (auto it = object.find(key); it != object.end()) {
+        return it->second;
+    }
+    throw std::runtime_error("JSON key not found: " + key);
+}
+
+JsonValue& JsonValue::operator[](const std::string& key) {
+    if (!isObject()) {
+        value_ = Object{};
+    }
+    auto& object = std::get<Object>(value_);
+    return object[key];
+}
+
+const JsonValue& JsonValue::at(std::size_t index) const {
+    if (!isArray()) {
+        throw std::runtime_error("JSON value is not an array");
+    }
+    const auto& array = std::get<Array>(value_);
+    if (index >= array.size()) {
+        throw std::runtime_error("JSON array index out of range");
+    }
+    return array[index];
+}
+
+JsonValue parse(const std::string& text) {
+    Parser parser(text);
+    return parser.parse();
+}
+
+std::string stringify(const JsonValue& value, int indentSize) {
+    return stringifyImpl(value, indentSize, 0);
+}
+
+}

--- a/src/storage/SimpleJson.h
+++ b/src/storage/SimpleJson.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace simplejson {
+
+class JsonValue {
+public:
+    using Array = std::vector<JsonValue>;
+    using Object = std::map<std::string, JsonValue>;
+
+    JsonValue();
+    explicit JsonValue(std::nullptr_t);
+    explicit JsonValue(bool value);
+    explicit JsonValue(int64_t value);
+    explicit JsonValue(std::string value);
+    JsonValue(const char* value);
+    explicit JsonValue(Array value);
+    explicit JsonValue(Object value);
+
+    bool isNull() const;
+    bool isBool() const;
+    bool isNumber() const;
+    bool isString() const;
+    bool isArray() const;
+    bool isObject() const;
+
+    bool asBool() const;
+    int64_t asInt() const;
+    const std::string& asString() const;
+    const Array& asArray() const;
+    Array& asArray();
+    const Object& asObject() const;
+    Object& asObject();
+
+    bool contains(const std::string& key) const;
+    const JsonValue& at(const std::string& key) const;
+    JsonValue& operator[](const std::string& key);
+
+    const JsonValue& at(std::size_t index) const;
+
+private:
+    std::variant<std::nullptr_t, bool, int64_t, std::string, Array, Object> value_;
+};
+
+JsonValue parse(const std::string& text);
+std::string stringify(const JsonValue& value, int indentSize = 2);
+
+}

--- a/src/utils/DiceRoller.cpp
+++ b/src/utils/DiceRoller.cpp
@@ -1,0 +1,32 @@
+#include "utils/DiceRoller.h"
+
+#include <algorithm>
+#include <chrono>
+
+namespace initiative {
+
+DiceRoller::DiceRoller()
+    : DiceRoller(static_cast<std::uint32_t>(
+          std::chrono::high_resolution_clock::now().time_since_epoch().count())) {}
+
+DiceRoller::DiceRoller(std::uint32_t seed)
+    : engine_(seed) {}
+
+int DiceRoller::rollD20(Mode mode) {
+    const int first = distribution_(engine_);
+    if (mode == Mode::Normal) {
+        return first;
+    }
+
+    const int second = distribution_(engine_);
+    if (mode == Mode::Advantage) {
+        return std::max(first, second);
+    }
+    return std::min(first, second);
+}
+
+int DiceRoller::rollInitiative(int dexMod, Mode mode) {
+    return rollD20(mode) + dexMod;
+}
+
+}

--- a/src/utils/DiceRoller.h
+++ b/src/utils/DiceRoller.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <random>
+
+namespace initiative {
+
+class DiceRoller {
+public:
+    enum class Mode { Normal, Advantage, Disadvantage };
+
+    DiceRoller();
+    explicit DiceRoller(std::uint32_t seed);
+
+    int rollD20(Mode mode = Mode::Normal);
+    int rollInitiative(int dexMod, Mode mode = Mode::Normal);
+
+private:
+    std::mt19937 engine_;
+    std::uniform_int_distribution<int> distribution_{1, 20};
+};
+
+}

--- a/src/utils/Settings.cpp
+++ b/src/utils/Settings.cpp
@@ -1,0 +1,98 @@
+#include "utils/Settings.h"
+
+#include "storage/SimpleJson.h"
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace initiative {
+
+Settings::Settings(std::filesystem::path filePath)
+    : filePath_(std::move(filePath)) {}
+
+void Settings::load() {
+    std::ifstream input(filePath_);
+    if (!input) {
+        return;
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    simplejson::JsonValue data = simplejson::parse(buffer.str());
+    const auto& object = data.asObject();
+
+    if (data.contains("theme")) {
+        theme_ = data.at("theme").asString();
+    }
+    if (data.contains("autosaveMinutes")) {
+        autosaveIntervalMinutes_ = static_cast<int>(data.at("autosaveMinutes").asInt());
+    }
+    if (data.contains("lastFiles")) {
+        lastFiles_.clear();
+        for (const auto& entry : data.at("lastFiles").asArray()) {
+            lastFiles_.push_back(entry.asString());
+        }
+    }
+    if (data.contains("streamerMode")) {
+        streamerMode_ = data.at("streamerMode").asBool();
+    }
+}
+
+void Settings::save() const {
+    if (!filePath_.parent_path().empty()) {
+        std::filesystem::create_directories(filePath_.parent_path());
+    }
+
+    simplejson::JsonValue::Object object;
+    object.emplace("theme", simplejson::JsonValue(theme_));
+    object.emplace("autosaveMinutes", simplejson::JsonValue(static_cast<int64_t>(autosaveIntervalMinutes_)));
+
+    simplejson::JsonValue::Array filesArray;
+    for (const auto& file : lastFiles_) {
+        filesArray.emplace_back(simplejson::JsonValue(file));
+    }
+    object.emplace("lastFiles", simplejson::JsonValue(std::move(filesArray)));
+    object.emplace("streamerMode", simplejson::JsonValue(streamerMode_));
+
+    std::ofstream output(filePath_);
+    if (!output) {
+        throw std::runtime_error("Unable to write settings file: " + filePath_.string());
+    }
+    output << simplejson::stringify(simplejson::JsonValue(std::move(object)), 2);
+}
+
+void Settings::setTheme(const std::string& theme) {
+    theme_ = theme;
+}
+
+const std::string& Settings::theme() const {
+    return theme_;
+}
+
+void Settings::setAutosaveIntervalMinutes(int minutes) {
+    autosaveIntervalMinutes_ = std::max(1, minutes);
+}
+
+int Settings::autosaveIntervalMinutes() const {
+    return autosaveIntervalMinutes_;
+}
+
+void Settings::setLastFiles(std::vector<std::string> files) {
+    lastFiles_ = std::move(files);
+}
+
+const std::vector<std::string>& Settings::lastFiles() const {
+    return lastFiles_;
+}
+
+void Settings::setStreamerMode(bool enabled) {
+    streamerMode_ = enabled;
+}
+
+bool Settings::streamerMode() const {
+    return streamerMode_;
+}
+
+}

--- a/src/utils/Settings.h
+++ b/src/utils/Settings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace initiative {
+
+class Settings {
+public:
+    explicit Settings(std::filesystem::path filePath);
+
+    void load();
+    void save() const;
+
+    void setTheme(const std::string& theme);
+    const std::string& theme() const;
+
+    void setAutosaveIntervalMinutes(int minutes);
+    int autosaveIntervalMinutes() const;
+
+    void setLastFiles(std::vector<std::string> files);
+    const std::vector<std::string>& lastFiles() const;
+
+    void setStreamerMode(bool enabled);
+    bool streamerMode() const;
+
+private:
+    std::filesystem::path filePath_;
+    std::string theme_{"dark"};
+    int autosaveIntervalMinutes_{2};
+    std::vector<std::string> lastFiles_;
+    bool streamerMode_{false};
+};
+
+}

--- a/tests/TestTurnManager.cpp
+++ b/tests/TestTurnManager.cpp
@@ -1,0 +1,172 @@
+#include "core/InitiativeTracker.h"
+#include "storage/EncounterStore.h"
+#include "storage/RosterStore.h"
+
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace initiative;
+
+namespace {
+struct TestFailure : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+#define EXPECT_TRUE(expr)                                                                      \
+    do {                                                                                       \
+        if (!(expr)) {                                                                         \
+            throw TestFailure(std::string("Expectation failed: ") + #expr + " at " + __FILE__ + ":" + std::to_string(__LINE__)); \
+        }                                                                                      \
+    } while (false)
+
+#define EXPECT_EQ(lhs, rhs) EXPECT_TRUE((lhs) == (rhs))
+
+void testInitiativeSorting() {
+    Combatant a{1, "Bandit", 12, 2, false, true, 11, 12};
+    Combatant b{2, "alpha", 15, 2, false, true, 11, 12};
+    Combatant c{3, "Hero", 15, 2, true, true, 24, 16};
+    Combatant d{4, "Scout", 15, 3, false, true, 10, 13};
+    Combatant e{5, "Bravo", 18, 0, false, true, 8, 13};
+
+    InitiativeTracker tracker;
+    tracker.setCombatants({a, b, c, d, e});
+
+    const auto& sorted = tracker.combatants();
+    EXPECT_EQ(sorted.size(), 5U);
+    EXPECT_EQ(sorted[0].name, "Bravo");
+    EXPECT_EQ(sorted[1].name, "Scout");
+    EXPECT_EQ(sorted[2].name, "Hero");
+    EXPECT_EQ(sorted[3].name, "alpha");
+    EXPECT_EQ(sorted[4].name, "Bandit");
+}
+
+void testConditionDecrement() {
+    Combatant acting{1, "Caster", 15, 3, true, true, 30, 15};
+    acting.conditions = {{"Bless", 1}, {"Shield of Faith", 2}};
+    Combatant ally{2, "Ally", 14, 1, true, true, 20, 15};
+
+    InitiativeTracker tracker;
+    tracker.setCombatants({ally, acting});
+    tracker.setRound(1);
+
+    tracker.nextTurn();
+
+    const auto& combatants = tracker.combatants();
+    const auto& updated = combatants.front();
+    EXPECT_EQ(updated.conditions.size(), 1U);
+    EXPECT_EQ(updated.conditions.front().name, "Shield of Faith");
+    EXPECT_EQ(updated.conditions.front().remainingRounds, 1);
+}
+
+void testDeathSaves() {
+    DeathSaves saves;
+    saves.addSuccess();
+    saves.addSuccess();
+    saves.addSuccess();
+    EXPECT_TRUE(saves.stable);
+    EXPECT_TRUE(!saves.dead);
+
+    saves.reset();
+    saves.addFailure();
+    saves.addFailure();
+    saves.addFailure();
+    EXPECT_TRUE(saves.dead);
+}
+
+void testMassAddNaming() {
+    const auto dataDir = std::filesystem::path(__FILE__).parent_path() / ".." / "data";
+    RosterStore roster;
+    roster.loadCharacters(dataDir / "characters.json");
+    roster.loadGroups(dataDir / "groups.json");
+
+    int nextId = 10;
+    auto combatants = roster.instantiateGroup("Bandit Ambush", nextId);
+
+    EXPECT_EQ(combatants.size(), 4U);
+    EXPECT_EQ(combatants[0].name, "Bandit 01");
+    EXPECT_EQ(combatants[1].name, "Bandit 02");
+    EXPECT_EQ(combatants[2].name, "Bandit 03");
+    EXPECT_EQ(combatants[3].name, "Bandit 04");
+}
+
+void testEncounterRoundTrip() {
+    EncounterData encounter;
+    encounter.round = 2;
+    encounter.turnIndex = 1;
+    encounter.combatants = {
+        Combatant{42, "Vaelen", 17, 3, true, true, 27, 17},
+        Combatant{43, "Bandit", 13, 2, false, true, 11, 12},
+    };
+    encounter.combatants[0].conditions = {{"Bless", 3}};
+    encounter.combatants[1].deathSaves.failures = 1;
+
+    const auto tempPath = std::filesystem::temp_directory_path() / "encounter_roundtrip.json";
+    EncounterStore::saveToFile(encounter, tempPath);
+    const auto loaded = EncounterStore::loadFromFile(tempPath);
+    std::filesystem::remove(tempPath);
+
+    EXPECT_EQ(loaded.schema, encounter.schema);
+    EXPECT_EQ(loaded.round, encounter.round);
+    EXPECT_EQ(loaded.turnIndex, encounter.turnIndex);
+    EXPECT_EQ(loaded.combatants.size(), encounter.combatants.size());
+    for (std::size_t i = 0; i < loaded.combatants.size(); ++i) {
+        const auto& lhs = loaded.combatants[i];
+        const auto& rhs = encounter.combatants[i];
+        EXPECT_EQ(lhs.id, rhs.id);
+        EXPECT_EQ(lhs.name, rhs.name);
+        EXPECT_EQ(lhs.initiative, rhs.initiative);
+        EXPECT_EQ(lhs.dexMod, rhs.dexMod);
+        EXPECT_EQ(lhs.isPC, rhs.isPC);
+        EXPECT_EQ(lhs.conscious, rhs.conscious);
+        EXPECT_EQ(lhs.hp, rhs.hp);
+        EXPECT_EQ(lhs.ac, rhs.ac);
+        EXPECT_EQ(lhs.notes, rhs.notes);
+        EXPECT_EQ(lhs.deathSaves.successes, rhs.deathSaves.successes);
+        EXPECT_EQ(lhs.deathSaves.failures, rhs.deathSaves.failures);
+        EXPECT_EQ(lhs.deathSaves.dead, rhs.deathSaves.dead);
+        EXPECT_EQ(lhs.deathSaves.stable, rhs.deathSaves.stable);
+        EXPECT_EQ(lhs.conditions.size(), rhs.conditions.size());
+        for (std::size_t c = 0; c < lhs.conditions.size(); ++c) {
+            EXPECT_EQ(lhs.conditions[c].name, rhs.conditions[c].name);
+            EXPECT_EQ(lhs.conditions[c].remainingRounds, rhs.conditions[c].remainingRounds);
+        }
+    }
+}
+
+#undef EXPECT_EQ
+#undef EXPECT_TRUE
+
+} // namespace
+
+int main() {
+    struct TestCase {
+        std::string name;
+        std::function<void()> func;
+    };
+
+    const std::vector<TestCase> tests = {
+        {"Initiative sorting", testInitiativeSorting},
+        {"Condition decrement", testConditionDecrement},
+        {"Death saves", testDeathSaves},
+        {"Mass add naming", testMassAddNaming},
+        {"Encounter round trip", testEncounterRoundTrip},
+    };
+
+    int failures = 0;
+    for (const auto& test : tests) {
+        try {
+            test.func();
+            std::cout << "[PASS] " << test.name << "\n";
+        } catch (const std::exception& ex) {
+            ++failures;
+            std::cout << "[FAIL] " << test.name << ": " << ex.what() << "\n";
+        }
+    }
+
+    std::cout << tests.size() - failures << "/" << tests.size() << " tests passed." << std::endl;
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- remove the Qt-specific targets and build a self-contained console application and unit test harness
- implement core combatant, turn-tracking, storage, and settings components using standard C++ utilities plus a lightweight JSON parser
- update documentation, sample main program, and tests to exercise initiative logic, persistence, and roster naming without Qt dependencies

## Testing
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e10d8206f883249ce4adef1a2eef9c